### PR TITLE
chore(gtex_manifest):update peregrine

### DIFF
--- a/dcp.bionimbus.org/manifest.json
+++ b/dcp.bionimbus.org/manifest.json
@@ -13,7 +13,7 @@
     "arranger-adminapi": "quay.io/cdis/arranger-server:master",
     "fence": "quay.io/cdis/fence:master",
     "indexd": "quay.io/cdis/indexd:master",
-    "peregrine": "quay.io/cdis/peregrine:master",
+    "peregrine": "quay.io/cdis/peregrine:feat_bagit",
     "pidgin": "quay.io/cdis/pidgin:master",
     "revproxy": "nginx:1.13.9-perl",
     "sheepdog": "quay.io/cdis/sheepdog:master",


### PR DESCRIPTION
Zac suggested to keep "peregrine": "quay.io/cdis/peregrine:feat_bagit" 