### PR TITLE
feat/arranger-indices: update arranger config

### DIFF
--- a/dcf-interop.kidsfirstdrc.org/manifest.json
+++ b/dcf-interop.kidsfirstdrc.org/manifest.json
@@ -29,7 +29,7 @@
   "arranger": {
     "project_id": "kidsfirst",
     "auth_filter_field": "auth_resource_path",
-    "auth_filter_node_type": "participant"
+    "auth_filter_node_types": ["participant"]
   },
   "tube": {
     "es_index_name": "kidsfirst_0"

--- a/dcp.bionimbus.org/manifest.json
+++ b/dcp.bionimbus.org/manifest.json
@@ -24,7 +24,8 @@
     "tube": "quay.io/cdis/tube:master"
   },
   "arranger": {
-    "project_id": "dcp_1"
+    "project_id": "dcp_1",
+    "auth_filter_node_types": ["case"]
   },
   "tube": {
     "es_index_name": "dcp_1"

--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -29,7 +29,7 @@
     "arranger": {
     "project_id": "dcf_1",
     "auth_filter_field": "auth_resource_path",
-    "auth_filter_node_type": "subject"
+    "auth_filter_node_types": ["subject"]
   },
   "global": {
     "environment": "ncicrdcdemo",

--- a/niaid.bionimbus.org/manifest.json
+++ b/niaid.bionimbus.org/manifest.json
@@ -30,7 +30,7 @@
   "arranger": {
     "project_id": "niaid_3",
     "auth_filter_field": "auth_resource_path",
-    "auth_filter_node_type": "subject"
+    "auth_filter_node_types": ["subject"]
   },
   "tube": {
     "es_index_name": "niaid_beta"


### PR DESCRIPTION
[This arranger PR](https://github.com/uc-cdis/gen3-arranger/pull/9) changes the config variable `authFilterNodeType` to now be `authFilterNodeTypes` (plural), supporting injecting authorization filter graphql middleware for a list rather than a single node type. (All node types must still have the same name for resource path attribute, so this one is left alone.)