### PR TITLE
Updated data dictionaries with restrictions to age-related properties to prevent submission of PHI

### DIFF
--- a/acct.bionimbus.org/manifest.json
+++ b/acct.bionimbus.org/manifest.json
@@ -27,7 +27,7 @@
     "environment": "accountprod",
     "hostname": "acct.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:830067555646:certificate/ada3ae0c-0e2b-4c97-aeac-7f0923e03312",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/acctdictionary/master/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/acctdictionary/0.1.3/schema.json",
     "portal_app": "acct",
     "kube_bucket": "kube-accountprod-gen3",
     "logs_bucket": "logs-accountprod-gen3",

--- a/data.bloodpac.org/manifest.json
+++ b/data.bloodpac.org/manifest.json
@@ -38,7 +38,7 @@
     "environment": "bloodv2",
     "hostname": "data.bloodpac.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:562749638216:certificate/2af3ddb5-0629-4581-ab07-fa482af124f3",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/0.2.17/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/0.2.18/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bpa/user.yaml",
     "sync_from_dbgap": "False"

--- a/data.bloodpac.org/manifest.json
+++ b/data.bloodpac.org/manifest.json
@@ -38,7 +38,7 @@
     "environment": "bloodv2",
     "hostname": "data.bloodpac.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:562749638216:certificate/2af3ddb5-0629-4581-ab07-fa482af124f3",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/bpadictionary/0.2.16/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/0.2.17/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bpa/user.yaml",
     "sync_from_dbgap": "False"

--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -34,7 +34,7 @@
     "environment": "bhcprodv2",
     "hostname": "data.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.5/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.6/schema.json",
     "portal_app": "bhc",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
     "sync_from_dbgap": "False"

--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -34,7 +34,7 @@
     "environment": "bhcprodv2",
     "hostname": "data.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.3/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.4/schema.json",
     "portal_app": "bhc",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
     "sync_from_dbgap": "False"

--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -34,7 +34,7 @@
     "environment": "bhcprodv2",
     "hostname": "data.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.4/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.4.5/schema.json",
     "portal_app": "bhc",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
     "sync_from_dbgap": "False"

--- a/dcf-interop.kidsfirstdrc.org/manifest.json
+++ b/dcf-interop.kidsfirstdrc.org/manifest.json
@@ -35,7 +35,7 @@
     "environment": "kfqa",
     "hostname": "dcf-interop.kidsfirstdrc.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:222487244010:certificate/1d90c400-8210-4443-ac79-4a6f2535e464",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/kf-dictionary/1.1.0/schema.json",
+    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/kf-dictionary/1.1.1/schema.json",
     "portal_app": "kfDcfInterop",
     "kube_bucket": "kube-kfqa-gen3",
     "logs_bucket": "logs-kfqa-gen3",

--- a/dcp.bionimbus.org/manifest.json
+++ b/dcp.bionimbus.org/manifest.json
@@ -37,7 +37,7 @@
     "environment": "gtexprod",
     "hostname": "dcp.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/b4fa52e9-7c8e-4499-b5d9-3d6decc448b3",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.0.11/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.0.12/schema.json",
     "portal_app": "gtex",
     "kube_bucket": "kube-gtexprod-gen3",
     "logs_bucket": "logs-gtexprod-gen3",

--- a/dcp.bionimbus.org/manifest.json
+++ b/dcp.bionimbus.org/manifest.json
@@ -37,7 +37,7 @@
     "environment": "gtexprod",
     "hostname": "dcp.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/b4fa52e9-7c8e-4499-b5d9-3d6decc448b3",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.0.12/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.0.13/schema.json",
     "portal_app": "gtex",
     "kube_bucket": "kube-gtexprod-gen3",
     "logs_bucket": "logs-gtexprod-gen3",

--- a/ibdgc.datacommons.io/manifest.json
+++ b/ibdgc.datacommons.io/manifest.json
@@ -27,7 +27,7 @@
     "environment": "ibdgc-prod",
     "hostname": "ibdgc.datacommons.io",
     "revproxy_arn": "arn:aws:acm:us-east-1:980870151884:certificate/d4bc881b-b404-4bef-912f-ed67785f953c",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/master/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/0.0.1/schema.json",
     "portal_app": "ibdgc",
     "kube_bucket": "kube-ibdgc-prod-gen3",
     "logs_bucket": "s3logs-logs-ibdgc-prod-gen3"

--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -35,7 +35,7 @@
     "environment": "ncicrdcdemo",
     "hostname": "nci-crdc-demo.datacommons.io",
     "revproxy_arn": "arn:aws:acm:us-east-1:662843554732:certificate/98e9b832-077a-4fdc-8f0a-06e9279f7359",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/dcfdictionary/2.3/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/dcfdictionary/2.4/schema.json",
     "portal_app": "ncrdc-demo",
     "kube_bucket": "kube-ncicrdcdemo-gen3",
     "logs_bucket": "logs-ncicrdcdemo-gen3",

--- a/niaid.bionimbus.org/manifest.json
+++ b/niaid.bionimbus.org/manifest.json
@@ -39,7 +39,7 @@
     "environment": "niaidprod",
     "hostname": "niaid.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:636151780898:certificate/07014a42-0e88-40f3-bc84-6ae664036fec",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.1.22/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.1.23/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-niaidprod-gen3",
     "logs_bucket": "logs-niaidprod-gen3",

--- a/niaid.bionimbus.org/manifest.json
+++ b/niaid.bionimbus.org/manifest.json
@@ -39,7 +39,7 @@
     "environment": "niaidprod",
     "hostname": "niaid.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:636151780898:certificate/07014a42-0e88-40f3-bc84-6ae664036fec",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.1.21/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.1.22/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-niaidprod-gen3",
     "logs_bucket": "logs-niaidprod-gen3",


### PR DESCRIPTION
The following dictionaries were updated:
ACCOuNT
BloodPAC (BPA)
BRAIN Commons (BHC)
DCP (Gtex)
IBD
Kids First (KF)
NCI-CRDC (DCF)
NIAID (NDH)