### PR TITLE
Update niaid dictionary release version

### DIFF
--- a/niaid.bionimbus.org/manifest.json
+++ b/niaid.bionimbus.org/manifest.json
@@ -38,7 +38,7 @@
     "environment": "niaidprod",
     "hostname": "niaid.bionimbus.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:636151780898:certificate/07014a42-0e88-40f3-bc84-6ae664036fec",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.3.6.1/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ndhdictionary/3.4.1/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-niaidprod-gen3",
     "logs_bucket": "logs-niaidprod-gen3",


### PR DESCRIPTION
From 3.3.6.1 to 3.4.1
The reason for the big jump is that recent changes were made to allow for the import of PATRIC's data into niaid
This was release 3.4.0
But it was discovered only after the fact that releases 3.3.7 and 3.3.8 "broke things",
and the updates for PATRIC were made on the dictionary which included the changes which broke things
So the problematic changes had to be reverted before deploying the PATRIC updates to production
Reverting those changes brings us to release 3.4.1

