### PR TITLE
Updated BRAIN commons dd to v0.6.1

### DIFF
--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -60,7 +60,7 @@
     "environment": "bhcprodv2",
     "hostname": "data.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.6.0/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/0.6.1/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
     "dispatcher_job_num": "10",


### PR DESCRIPTION
removed sample node self-reference