### PR TITLE
Bump Guppy to 0.2 for canine prod

### DIFF
--- a/caninedc.org/manifest.json
+++ b/caninedc.org/manifest.json
@@ -20,7 +20,7 @@
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.7",
-    "guppy": "quay.io/cdis/guppy:0.1.2",
+    "guppy": "quay.io/cdis/guppy:0.2.0",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:0.0.5"
   },
   "jupyterhub": {


### PR DESCRIPTION
uc-cdis/cloud-automation#869 depends on Guppy 0.2, see also uc-cdis/guppy#39