### PR TITLE
feat(stage): update sower with resource limit support

### DIFF
--- a/gen3.datastage.io/manifest.json
+++ b/gen3.datastage.io/manifest.json
@@ -44,8 +44,8 @@
       "image": "quay.io/cdis/pelican:0.1.0",
       "pull_policy": "always",
       "env": [],
-      "cpu_limit": "1",
-      "memory_limit": "12Gi"
+      "cpu-limit": "1",
+      "memory-limit": "12Gi"
     },
     "restart_policy": "never"
   },

--- a/gen3.datastage.io/manifest.json
+++ b/gen3.datastage.io/manifest.json
@@ -23,7 +23,7 @@
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.7",
     "guppy": "quay.io/cdis/guppy:0.2.0",
-    "sower": "quay.io/cdis/sower:0.2.0",
+    "sower": "quay.io/cdis/sower:0.2.1",
     "hatchery": "quay.io/cdis/hatchery:0.1.0",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
     "wts": "quay.io/cdis/workspace-token-service:master",
@@ -43,7 +43,9 @@
       "name": "job-task",
       "image": "quay.io/cdis/pelican:0.1.0",
       "pull_policy": "always",
-      "env": []
+      "env": [],
+      "cpu_limit": "1",
+      "memory_limit": "12Gi"
     },
     "restart_policy": "never"
   },


### PR DESCRIPTION
Update to use latest `sower` version `0.2.1` with resource limits.