### PR TITLE
Automated manifest pr for gen3.datastage.io at 07/10/2019 15:45 

### DIFF
--- a/gen3.datastage.io/manifest.json
+++ b/gen3.datastage.io/manifest.json
@@ -7,17 +7,17 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:1.2.1",
+    "arborist": "quay.io/cdis/arborist:2.0.1",
     "arranger": "quay.io/cdis/arranger:1.0.3",
     "arranger-dashboard": "quay.io/cdis/arranger-dashboard:master",
     "arranger-adminapi": "quay.io/cdis/arranger-server:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2.8.2.1",
-    "indexd": "quay.io/cdis/indexd:1.0.10",
+    "fence": "quay.io/cdis/fence:3.2.4",
+    "indexd": "quay.io/cdis/indexd:1.1.4",
     "peregrine": "quay.io/cdis/peregrine:feat_bagit2",
-    "pidgin": "quay.io/cdis/pidgin:1.0.0",
+    "pidgin": "quay.io/cdis/pidgin:1.1.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.10",
+    "sheepdog": "quay.io/cdis/sheepdog:1.1.13",
     "portal": "quay.io/cdis/data-portal:2.14.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
@@ -43,7 +43,9 @@
       "name": "job-task",
       "image": "quay.io/cdis/pelican:0.1.0",
       "pull_policy": "always",
-      "env": [],
+      "env": [
+
+      ],
       "cpu-limit": "1",
       "memory-limit": "12Gi"
     },
@@ -57,107 +59,176 @@
       "cpu-limit": "1.0",
       "memory-limit": "256Mi",
       "image": "quay.io/cdis/gen3fuse-sidecar:chore_sidecar",
-      "env": {"NAMESPACE":"default", "HOSTNAME": "gen3.datastage.io"},
-      "args": [],
-      "command": ["/bin/bash", "/sidecarDockerrun.sh"],
-      "lifecycle-pre-stop": ["su", "-c", "echo test", "-s", "/bin/sh", "root"]
+      "env": {
+        "NAMESPACE": "default",
+        "HOSTNAME": "gen3.datastage.io"
+      },
+      "args": [
+
+      ],
+      "command": [
+        "/bin/bash",
+        "/sidecarDockerrun.sh"
+      ],
+      "lifecycle-pre-stop": [
+        "su",
+        "-c",
+        "echo test",
+        "-s",
+        "/bin/sh",
+        "root"
+      ]
     },
-    "containers": [{
-      "target-port": 8787,
-      "cpu-limit": "1.0",
-      "memory-limit": "512Mi",
-      "name": "R Studio",
-      "image": "heliumdatastage/rstudio-server:1",
-      "env": {"DISABLE_AUTH": "true"},
-      "args": [],
-      "path-rewrite": "/",
-      "use-tls": "false",
-      "ready-probe": "/"
-    },{
-      "target-port": 8888,
-      "cpu-limit": "1.0",
-      "memory-limit": "512Mi",
-      "name": "Jupyter Notebook Bio Python",
-      "image": "quay.io/occ_data/jupyternotebook:1.7.2",
-      "env": {},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.password=''","--NotebookApp.token=''"],
-      "command": ["start-notebook.sh"],
-      "path-rewrite": "/lw-workspace/proxy/",
-      "use-tls": "false",
-      "ready-probe": "/lw-workspace/proxy/",
-      "lifecycle-post-start": ["/bin/sh","-c","export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"],
-      "user-uid": 1000,
-      "fs-gid": 100,
-      "user-volume-location": "/home/jovyan/pd"
-    },{
-      "target-port": 8888,
-      "cpu-limit": "1.0",
-      "memory-limit": "8096Mi",
-      "name": "Helium Autoencoder Demo",
-      "image": "quay.io/cdis/auntoencoder-copd-demo:latest",
-      "env": {},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.password=''","--NotebookApp.token=''"],
-      "command": ["start-notebook.sh"],
-      "path-rewrite": "/lw-workspace/proxy/",
-      "use-tls": "false",
-      "ready-probe": "/lw-workspace/proxy/",
-      "lifecycle-post-start": ["/bin/sh","-c","export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"],
-      "user-uid": 1000,
-      "fs-gid": 100
-    },{
-      "target-port": 8888,
-      "cpu-limit": "1.0",
-      "memory-limit": "8096Mi",
-      "name": "Helium Tensorflow-Pytorch",
-      "image": "heliumdatastage/tensorflow-pytorch-ext:1",
-      "env": {},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.password=''","--NotebookApp.token=''"],
-      "command": ["start-notebook.sh"],
-      "path-rewrite": "/lw-workspace/proxy/",
-      "use-tls": "false",
-      "ready-probe": "/lw-workspace/proxy/",
-      "lifecycle-post-start": ["/bin/sh","-c","export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"],
-      "user-uid": 1000,
-      "fs-gid": 100
-    },{
-      "target-port": 8888,
-      "cpu-limit": "1.0",
-      "memory-limit": "8096Mi",
-      "name": "Helium CIP Demo",
-      "image": "heliumdatastage/jup-cip:v1",
-      "env": {},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.password=''","--NotebookApp.token=''"],
-      "command": ["start-notebook.sh"],
-      "path-rewrite": "/lw-workspace/proxy/",
-      "use-tls": "false",
-      "ready-probe": "/lw-workspace/proxy/",
-      "lifecycle-post-start": ["/bin/sh","-c","export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"],
-      "user-uid": 1000,
-      "fs-gid": 100
-    }]
+    "containers": [
+      {
+        "target-port": 8787,
+        "cpu-limit": "1.0",
+        "memory-limit": "512Mi",
+        "name": "R Studio",
+        "image": "heliumdatastage/rstudio-server:1",
+        "env": {
+          "DISABLE_AUTH": "true"
+        },
+        "args": [
+
+        ],
+        "path-rewrite": "/",
+        "use-tls": "false",
+        "ready-probe": "/"
+      },
+      {
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "512Mi",
+        "name": "Jupyter Notebook Bio Python",
+        "image": "quay.io/occ_data/jupyternotebook:1.7.2",
+        "env": {
+        },
+        "args": [
+          "--NotebookApp.base_url=/lw-workspace/proxy/",
+          "--NotebookApp.password=''",
+          "--NotebookApp.token=''"
+        ],
+        "command": [
+          "start-notebook.sh"
+        ],
+        "path-rewrite": "/lw-workspace/proxy/",
+        "use-tls": "false",
+        "ready-probe": "/lw-workspace/proxy/",
+        "lifecycle-post-start": [
+          "/bin/sh",
+          "-c",
+          "export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"
+        ],
+        "user-uid": 1000,
+        "fs-gid": 100,
+        "user-volume-location": "/home/jovyan/pd"
+      },
+      {
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "8096Mi",
+        "name": "Helium Autoencoder Demo",
+        "image": "quay.io/cdis/auntoencoder-copd-demo:latest",
+        "env": {
+        },
+        "args": [
+          "--NotebookApp.base_url=/lw-workspace/proxy/",
+          "--NotebookApp.password=''",
+          "--NotebookApp.token=''"
+        ],
+        "command": [
+          "start-notebook.sh"
+        ],
+        "path-rewrite": "/lw-workspace/proxy/",
+        "use-tls": "false",
+        "ready-probe": "/lw-workspace/proxy/",
+        "lifecycle-post-start": [
+          "/bin/sh",
+          "-c",
+          "export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"
+        ],
+        "user-uid": 1000,
+        "fs-gid": 100
+      },
+      {
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "8096Mi",
+        "name": "Helium Tensorflow-Pytorch",
+        "image": "heliumdatastage/tensorflow-pytorch-ext:1",
+        "env": {
+        },
+        "args": [
+          "--NotebookApp.base_url=/lw-workspace/proxy/",
+          "--NotebookApp.password=''",
+          "--NotebookApp.token=''"
+        ],
+        "command": [
+          "start-notebook.sh"
+        ],
+        "path-rewrite": "/lw-workspace/proxy/",
+        "use-tls": "false",
+        "ready-probe": "/lw-workspace/proxy/",
+        "lifecycle-post-start": [
+          "/bin/sh",
+          "-c",
+          "export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"
+        ],
+        "user-uid": 1000,
+        "fs-gid": 100
+      },
+      {
+        "target-port": 8888,
+        "cpu-limit": "1.0",
+        "memory-limit": "8096Mi",
+        "name": "Helium CIP Demo",
+        "image": "heliumdatastage/jup-cip:v1",
+        "env": {
+        },
+        "args": [
+          "--NotebookApp.base_url=/lw-workspace/proxy/",
+          "--NotebookApp.password=''",
+          "--NotebookApp.token=''"
+        ],
+        "command": [
+          "start-notebook.sh"
+        ],
+        "path-rewrite": "/lw-workspace/proxy/",
+        "use-tls": "false",
+        "ready-probe": "/lw-workspace/proxy/",
+        "lifecycle-post-start": [
+          "/bin/sh",
+          "-c",
+          "export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; ln -s $(pwd) /home/$IAM/pd/dockerHome; mkdir -p /home/$IAM/.jupyter/custom; echo \"define(['base/js/namespace'], function(Jupyter){Jupyter._target = '_self';})\" >/home/$IAM/.jupyter/custom/custom.js; ln -s /data /home/$IAM/pd/; true"
+        ],
+        "user-uid": 1000,
+        "fs-gid": 100
+      }
+    ]
   },
   "jupyterhub": {
     "enabled": "yes",
     "containers": [
-                  {
-                    "name": "Bioinfo - Python/R",
-                    "cpu": 0.5,
-                    "memory": "256M",
-                    "image": "quay.io/occ_data/jupyternotebook:1.7.2"
-                  },
-                  {
-                    "name": "Bioinfo - Python/R",
-                    "cpu": 1.0,
-                    "memory": "1024M",
-                    "image": "quay.io/occ_data/jupyternotebook:1.7.2"
-                  },
-                  {
-                    "name": "Helium COPD Demo",
-                    "cpu": 1.0,
-                    "memory": "1024M",
-                    "image": "ananyak8srenci/autoencoder-copd-demo:1d33030cef16"
-                  }
-                ]
+      {
+        "name": "Bioinfo - Python/R",
+        "cpu": 0.5,
+        "memory": "256M",
+        "image": "quay.io/occ_data/jupyternotebook:1.7.2"
+      },
+      {
+        "name": "Bioinfo - Python/R",
+        "cpu": 1.0,
+        "memory": "1024M",
+        "image": "quay.io/occ_data/jupyternotebook:1.7.2"
+      },
+      {
+        "name": "Helium COPD Demo",
+        "cpu": 1.0,
+        "memory": "1024M",
+        "image": "ananyak8srenci/autoencoder-copd-demo:1d33030cef16"
+      }
+    ]
   },
   "global": {
     "environment": "stageprod",


### PR DESCRIPTION
# arborist # Release Notes

For: uc-cdis/arborist

Notes since tag: 1.2.1

Notes to tag/commit: 2.0.1

Generated: 2019-07-10



## Deployment Changes
  - Database deployment (#42)
  - See `migrations` folder for database schema and setup utilities (#42)

## New Features
  - Support using resource tags directly in auth request (#86)
  - Add QS param `?p` to `POST /resource` which will make arborist create 
    parent resources for your request if they didn't exist already. (#81)
  - Add coveralls integration for code coverage analytics. (#80)
  - Add QS parameter ?tags for /auth/resources which will make it output tags 
    instead of paths. (#70)
  - The /user/{name}/resources endpoint also supports this. (#70)
  - db migration & utilities (#42)
  - Add db migration automation and use this for the travis setup so travis is 
    actually running tests on postgres backend (#42)
  - Add documentation on migration commands & utility scripts (#42)
  - Add CRUD endpoints for users & groups as well as granting policies (#42)
  - Add tests for REST API & database operations (#42)
  - Add documentation & examples on tests (#42)
  - Add resource rules lexer & parser for handling simple logic in auth 
    requests (#42)
  - Added client (#53)
  - Check client permission (#53)
  - Add `anonymous` and `logged-in` groups which can be given their own 
    policies (though they can't contain users). Policies granted to the 
    anonymous group allow to all users, whether or not they have a token, and 
    the ones granted to `logged-in` apply to all users with a JWT. (#58)
  - Also update the README a bit; there was a duplicated section that's removed 
    now. (#58)
  - Add tag field to the resources which should be used in cases such as in 
    indexd where we want to maintain a persistent reference to a resource in 
    arborist, whose name & path are potentially mutable. (#56)
  - Add method for revoking all user policies (for supporting fence sync) (#50)
  - API documentation on users/groups (#48)
  - Add groups API (#45)
  - Add API for granting/revoking policies on users & groups (#45)
  - Add tests for new APIs (#45)
  - Add user CRUD endpoints (#44)
  - Add tests for user endpoints (#44)
  - Added resource rules yacc lexer and parser (#40)
  - Implemented `auth/request` and `auth/proxy` (#40)
  - Added lazy prepared statement cache (#40)
  - Add more db migration automation and use this for the travis setup (#41)
  - `db_version` table now stores integer ID and text for the version, not 
    postgres date (more robust for applying new migrations) (#41)
  - Add documentation on migration commands & utility scripts (#41)
  - Add tests for REST API & database operations (#41)
  - Add documentation & examples on tests (#41)

## Improvements
  - Add some more cute badges to the readme. (#83)
  - Return the resource body on 409s from resource creation so the caller can 
    still see the tag for the existing resource. (#78)
  - Consolidate the resource create code together so subresources aren't a 
    special case. (#77)
  - Include `logged-in` group by default in the list of groups for queried 
    users. (#73)
  - Simplify the DB schema by not using an internal "root" resource. (#59)
  - Add more tests ~for auth endpoints~. All the tests. (#52)
  - Improved the auth request query (#49)
  - README startup guide (#48)
  - Commandline argument documentation (#48)
  - Use test "fixtures" in a few additional places (not hardcoding test case 
    content everywhere it's used) (#45)

## Bug Fixes
  - Auth resources listings include all the resources below the authorized 
    resources. (#87)
  - Fix resource insert trigger to not make a new tag for existing resources. 
    (#85)
  - Don't alter resource tag on `PUT` request (#84)
  - Support `?p` flag on `PUT /resource/` (#84)
  - Fixed a few bugs in the OpenAPI docs (#79)
  - Listing resources for a user or doing an auth resources request includes 
    resources granted as the result of membership in groups. (#75)
  - Fix error handling on auth request (#72)
  - Fixes a bug causing the subresources to not submit. Submitting resources 
    should work as expected now. (#55)
  - Separates the `Resource` model into a `ResourceIn` (which is the format 
    which should be accepted from user input) and a `ResourceOut` (which is how 
    it should look when returned by the arborist API). The difference is that 
    inputs can specify the entire resource subtree. (#55)
  - Include group policies (#49)
  - `defer` did not have intended effect inside test runs, fixed to have 
    correct behavior (#44)
  - couple small fixes in db schema, run `make down` and `make up` to reset 
    this version (#44)
  - Fix resource name formatting in policies (`root.a.b.c` in db vs `/a/b/c` 
    responses & input) (#41)
  - `GET /resource` will return 404 correctly (#41)
  - `Server.MakeRouter` now takes `io.Writer` input so HTTP access logs can go 
    somewhere other than stdout (#41)
  - Fix a couple status codes (201 vs 204 on deletes) and use `http.Status*` 
    instead of numerals (#41)

# arranger # Release Notes

For: uc-cdis/gen3-arranger

Notes since tag: 1.0.3

Notes to tag/commit: f9353292f547ad9292fdfc6f351c23ba9937173e

Generated: 2019-07-10



## Improvements
  - added `GEN3_ARBORIST_ENDPOINT_OVERRIDE` (#13)

# fence # Release Notes

For: uc-cdis/fence

Notes since tag: 2.8.2.1

Notes to tag/commit: 3.2.4

Generated: 2019-07-10



## Improvements
  - dbgap sync will no longer create duplicate entries in arborist database for 
    user with lower & upper case name (#655)
  - service account validation will only verify that users on the Google 
    Project have access to the projects the *active* registered service account 
    have access to (in other words, expired service account project access 
    won't be checked since they don't actually have access to data) (#651)
  - fence will now consider authz field on indexd record to determine if a file 
    is public or not (for different signed url behavior). previously only 
    checked acl field (#653)
  - allow not providing a user.yaml (e.g. just a pure dbgap sync). previously 
    you had to pass an empty user.yaml (#641)
  - dbgap study to arborist resource namespace configuration (#641)
  - specify upstream idp to require user re-auth. caveat is some IdPs wouldn't 
    support it (#643)
  - The login endpoints now verify that the redirect provided is valid 
    according to fence: it redirects back to the Gen3 application, to an OAuth 
    client, or to some other approved URL from the configuration. (#540)
  - Deployment changes (#540)
  - Added optional new LOGIN_REDIRECT_WHITELIST config variable to allow for 
    redirecting to specific domains for login/logout. (#540)
  - Base class for different IDPs for Login (#593)
  - Update default configuration with details about setting up ORCID & 
    Microsoft OAuth 2 Clients (#593)
  - Better logging for sftp connections for dbgap syncing (#637)
  - filter SAWarning about not reflecting partial indices (#636)
  - Support providing alternative identity provider in oidc flow (#635)
  - use new gen3config instead of having all config code in fence (#592)
  - validate user.yaml files via gen3users tests before running usersync (#629)
  - Update user sync for compatibility with changes to arborist. (#613)
  - Policies now owned by arborist (#613)
  - Arborist needs (read-only) copy of users. (#613)
  - User info endpoint will return policy list from arborist for that user, if 
    available. (#604)

## Bug Fixes
  - fix exception when dbgap resources and user.yaml have a matching root level 
    resource without any subresources and create regression test (#656)
  - google-user-sa-validation calls dockerrun to start service now instead of 
    forcibly calling apache (was getting errors b/c fence is using nginx now) 
    (#654)
  - fix issue with service account registration where validation checks new 
    access *and* previous access when trying to update an SA (so if updating to 
    restrict to a subset of previous access, validation may fail and not allow 
    the update) (#651)
  - Re-add openssh back to image for sftp access to work correctly (#644)
  - fix error with logger if no user.yaml provided (#639)
  - can now successfully call `fence-create sync --sync_from_dbgap True` 
    without providing a valid `user.yaml` (e.g. just a dbgap sync) (#637)
  - Fix typos in exception handler (#626)

## New Features
  - dbgap syncing now updates resources in arborist (#641)
  - `SESSION_COOKIE_DOMAIN` is now configurable (#640)
  - Client policies can be managed in the user.yaml as long as the client 
    already exists in fence (#642)
  - use standard base image (#638)
  - Configure new clients with arborist policies using `--arborist` and 
    `--policies` flags for `fence-create` (#608)
  - Use arborist for authorization checks on downloading data files from 
    indexd, _as long as_ the `authz` field is present in the index record (#608)
  - swagger document for multipart upload presigned url (#616)
  - Allow setting policies for `anonymous` and `logged-in` groups in the 
    `user.yaml`. (#625)
  - Use arborist to check permission for indexd record upload/download on 
    records when supported (send `"rbac"` field from the indexd record to 
    arborist) (#606)

## Dependency Updates
  - bump sqlalchemy 0.9.9 to 1.3.3 (#630)
  - bump userdatamodel 1.5.0 to 1.5.1 (#630)
  - bump authlib from 0.9 to 0.11 (#628)

## Breaking Changes
  - remove `--verbose` option to `fence-create` CLI, prefers checking the 
    `DEBUG` value from config now to determine whether or not to output debug 
    logs (#647)
  - Users' RBAC policies are now owned by arborist, not fence, so the tables 
    are removed from fence/userdatamodel. (#608)
  - The usersync is updated to work specifically with the new arborist version. 
    (#608)
  - In general, this and following versions of fence should be deployed only 
    with 
    [arborist>=2.0.0](https://github.com/uc-cdis/arborist/releases/tag/2.0.0) 
    (#608)
  - Intended to work only with arborist >= 2.0 (using new database). Won't work 
    with older arborist API. (#613)
  - Remove (unused) RBAC blueprint (#606)
  - Questions: (#606)
  - stick with `"read-storage"`/`"write-storage"` ? (#606)

# indexd # Release Notes

For: uc-cdis/indexd

Notes since tag: 1.0.10

Notes to tag/commit: 02d6ed8d672137ee056faf019d562230b3acc348

Generated: 2019-07-10



## New Features
  - Add coveralls integration for code coverage analytics (#226)
  - Now Indexd calls Arborist for permission check (#215)
  - added new authz field (previously rbac field) (#214)
  - Changing from apache 2 to nginx (#213)
  - updating to uwsgi (#213)
  - Record now have a new `rbac` field (#209)
  - DRS v0.5.0 compliance (#188)
  - Update the blank record creation endpoint in indexd to support providing 
    the file name. (#197)

## Dependency Updates
  - bump sqlalchemy from 1.0.8 to 1.3.3 (#211)
  - bump sqlalchemy-utils from 0.32.21 to 0.33.11 (#211)
  - `gnupg2` is now installed when running tests with Docker (#189)

## Bug Fixes
  - Remove extra leading `/` in resource paths in migration (#221)
  - Fix log message (#221)
  - Make window size formatting string clearer (#221)
  - Fix Swagger doc BulkInputInfo model (#208)
  - Allow ACLs to be duplicated in submissions & updates but reduced to a 
    unique set. Fixes #204 (#207)
  - Fix Docker testing harness failing on start because `gnupg2` is not 
    installed. (#189)
  - Add bullet list to README (#194)

## Breaking Changes
  - Functionality of `POST /dataobjects/list` has been moved to `GET 
    /dataobjects`, and the parameters provided to this endpoint are now 
    specified as query parameters instead of in the request body. (#188)

## Deployment Changes
  - Add script to run for filling out records' `authz` fields based on the 
    `acl` fields. (#218)
  - cc @david4096 (#188)
  - The database table `index_record_ace`'s primary key is (did, acl), so we 
    shouldn't allow duplicates in the ACL list when making an IndexRecord. 
    Using a set removes the duplicates. (#198)

## Improvements
  - Specification of required and optional parameters has been properly 
    serialized in the schema. (#188)
  - `checksum` parameter is now optional for ListDataBundles and 
    ListDataObjects. (#188)
  - Minor changes for PEP8 compliance. (#188)
  - indexd records created during the data upload flow will contain the file 
    names. (#197)
  - update swagger docs (#186)

# pidgin # Release Notes

For: uc-cdis/pidgin

Notes since tag: 1.0.0

Notes to tag/commit: a4aa1d95a09f573b1f9202e70d7bb2cad6798205

Generated: 2019-07-10



## Dependency Updates
  - Bump PyYAML to 5.1 (#26)

## Improvements
  - add schemaorg example to swagger documentation (#28)
  - Add Jenkinsfile (#27)
  - Use the image tag instead of master (#25)

## Deployment Changes
  - use the latest version of the python 3 base image (#29)
  - The Dockerfile now uses an Alpine image (#24)

# sheepdog # Release Notes

For: uc-cdis/sheepdog

Notes since tag: 1.1.10

Notes to tag/commit: d7023b4f19dcdc8dcb5b8b839660834e4facba6a

Generated: 2019-07-10



## Deployment Changes
  - look for INDEX_CLIENT instead of SIGNPOST in app.config (#291)
  - get INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST (#291)

## Improvements
  - stops importing and using signpost, and stops calling index client signpost 
    where index client is already being used instead of signpost (#291)
  - renames various vbbs and fns to not be signpost-specific, eg "signpost_obj" 
    to "file_record" (#291)
  - Added missing index to make submission faster (#280)

## Breaking Changes
  - looks for INDEX_CLIENT instead of SIGNPOST in app.config and gets 
    INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST--you must therefore use 
    the latest cloud automation or manually recreate your sheepdog secrets 
    (#291)
  - removes the USE_SIGNPOST backwards-compatibility workarounds and testing, 
    since GDC forked sheepdog and signpost is dead (#291)
  - deprecate "related cases" caching--not a problem if CASE_CACHE was False 
    (#290)

## New Features
  - Accept consent codes during submission and include the consent codes in the 
    indexd record's `authz` field. (#288)

## Bug Fixes
  - Fixed a bug in Indexd API calling when base_url has subpath (#287)
  - Handle integrity Error when there are two transactions submit data to DB 
    (#282)

## Dependency Updates
  - bump gdcdictionary to gen3dictionary 2.0.0 (#292)
  - bump sqlalchemy from 0.9.9 to 1.3.5 (#278)
  - bump dictionaryutils from 2.0.4 to 2.0.7 (#278)
  - bump psqlgraph to 2.0.2 (#278)
  - bump gen3datamodel to 2.0.2 (#278)
  - bump indexd from 1.0.8 to 1.1.2 (#278)
  - bump authutils to 3.1.1 (#278)
  - bump requests to 2.22.0 (#278)
  - add rbac-client (#278)
  - bump datamodelutils to 0.4.7 (#278)
  - remove signpost and signpostclient from requirements (#291)
  - Remove cirrus from dev-requirements (#284)
  - Remove fence from dev-requirements (#284)
  - Remove userdatamodel from dev-requirements (#284)
  - datamodelutils bumped to 0.4.5 (#280)
  - datamodelutils latest version (#277)

# portal # Release Notes

For: uc-cdis/data-portal

Notes since tag: 2.14.0

Notes to tag/commit: fd6be3020958c359fb9b78714fe68d22836f6687

Generated: 2019-07-10



# spark # Release Notes

For: uc-cdis/gen3-spark

Notes since tag: 1.0.0

Notes to tag/commit: 00ef588fd7d64415afe396bc754a6b39d20d7638

Generated: 2019-07-10



# tube # Release Notes

For: uc-cdis/tube

Notes since tag: 0.3.7

Notes to tag/commit: 0.3.7

Generated: 2019-07-10



# guppy # Release Notes

For: uc-cdis/guppy

Notes since tag: 0.2.0

Notes to tag/commit: 0ee37110c19049974dcaf5c5eb57384a8793dfe3

Generated: 2019-07-10



## Improvements
  - Unit tests for auth, config, schema, filter and aggregation (#41)

