### PR TITLE
Automated manifest pr for genomel.bionimbus.org at 07/10/2019 15:45 

### DIFF
--- a/genomel.bionimbus.org/manifest.json
+++ b/genomel.bionimbus.org/manifest.json
@@ -7,18 +7,18 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:1.2.1",
-    "fence": "quay.io/cdis/fence:2.6.0",
-    "indexd": "quay.io/cdis/indexd:1.1.1",
-    "peregrine": "quay.io/cdis/peregrine:1.0.9",
-    "pidgin": "quay.io/cdis/pidgin:1.0.0",
+    "arborist": "quay.io/cdis/arborist:2.0.1",
+    "fence": "quay.io/cdis/fence:3.2.4",
+    "indexd": "quay.io/cdis/indexd:1.1.4",
+    "peregrine": "quay.io/cdis/peregrine:1.3.0",
+    "pidgin": "quay.io/cdis/pidgin:1.1.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.8",
-    "portal": "quay.io/cdis/data-portal:2.7.4",
+    "sheepdog": "quay.io/cdis/sheepdog:1.1.13",
+    "portal": "quay.io/cdis/data-portal:2.14.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
-    "tube": "quay.io/cdis/tube:0.1.9",
+    "tube": "quay.io/cdis/tube:0.3.7",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:0.0.6"
   },
   "jupyterhub": {


### PR DESCRIPTION
# arborist # Release Notes

For: uc-cdis/arborist

Notes since tag: 1.2.1

Notes to tag/commit: 2.0.1

Generated: 2019-07-10



## Improvements
  - Add some more cute badges to the readme. (#83)
  - Return the resource body on 409s from resource creation so the caller can 
    still see the tag for the existing resource. (#78)
  - Consolidate the resource create code together so subresources aren't a 
    special case. (#77)
  - Include `logged-in` group by default in the list of groups for queried 
    users. (#73)
  - Simplify the DB schema by not using an internal "root" resource. (#59)
  - Add more tests ~for auth endpoints~. All the tests. (#52)
  - Improved the auth request query (#49)
  - README startup guide (#48)
  - Commandline argument documentation (#48)
  - Use test "fixtures" in a few additional places (not hardcoding test case 
    content everywhere it's used) (#45)

## Bug Fixes
  - Auth resources listings include all the resources below the authorized 
    resources. (#87)
  - Fix resource insert trigger to not make a new tag for existing resources. 
    (#85)
  - Don't alter resource tag on `PUT` request (#84)
  - Support `?p` flag on `PUT /resource/` (#84)
  - Fixed a few bugs in the OpenAPI docs (#79)
  - Listing resources for a user or doing an auth resources request includes 
    resources granted as the result of membership in groups. (#75)
  - Fix error handling on auth request (#72)
  - Fixes a bug causing the subresources to not submit. Submitting resources 
    should work as expected now. (#55)
  - Separates the `Resource` model into a `ResourceIn` (which is the format 
    which should be accepted from user input) and a `ResourceOut` (which is how 
    it should look when returned by the arborist API). The difference is that 
    inputs can specify the entire resource subtree. (#55)
  - Include group policies (#49)
  - `defer` did not have intended effect inside test runs, fixed to have 
    correct behavior (#44)
  - couple small fixes in db schema, run `make down` and `make up` to reset 
    this version (#44)
  - Fix resource name formatting in policies (`root.a.b.c` in db vs `/a/b/c` 
    responses & input) (#41)
  - `GET /resource` will return 404 correctly (#41)
  - `Server.MakeRouter` now takes `io.Writer` input so HTTP access logs can go 
    somewhere other than stdout (#41)
  - Fix a couple status codes (201 vs 204 on deletes) and use `http.Status*` 
    instead of numerals (#41)

## Deployment Changes
  - Database deployment (#42)
  - See `migrations` folder for database schema and setup utilities (#42)

## New Features
  - Support using resource tags directly in auth request (#86)
  - Add QS param `?p` to `POST /resource` which will make arborist create 
    parent resources for your request if they didn't exist already. (#81)
  - Add coveralls integration for code coverage analytics. (#80)
  - Add QS parameter ?tags for /auth/resources which will make it output tags 
    instead of paths. (#70)
  - The /user/{name}/resources endpoint also supports this. (#70)
  - db migration & utilities (#42)
  - Add db migration automation and use this for the travis setup so travis is 
    actually running tests on postgres backend (#42)
  - Add documentation on migration commands & utility scripts (#42)
  - Add CRUD endpoints for users & groups as well as granting policies (#42)
  - Add tests for REST API & database operations (#42)
  - Add documentation & examples on tests (#42)
  - Add resource rules lexer & parser for handling simple logic in auth 
    requests (#42)
  - Added client (#53)
  - Check client permission (#53)
  - Add `anonymous` and `logged-in` groups which can be given their own 
    policies (though they can't contain users). Policies granted to the 
    anonymous group allow to all users, whether or not they have a token, and 
    the ones granted to `logged-in` apply to all users with a JWT. (#58)
  - Also update the README a bit; there was a duplicated section that's removed 
    now. (#58)
  - Add tag field to the resources which should be used in cases such as in 
    indexd where we want to maintain a persistent reference to a resource in 
    arborist, whose name & path are potentially mutable. (#56)
  - Add method for revoking all user policies (for supporting fence sync) (#50)
  - API documentation on users/groups (#48)
  - Add groups API (#45)
  - Add API for granting/revoking policies on users & groups (#45)
  - Add tests for new APIs (#45)
  - Add user CRUD endpoints (#44)
  - Add tests for user endpoints (#44)
  - Added resource rules yacc lexer and parser (#40)
  - Implemented `auth/request` and `auth/proxy` (#40)
  - Added lazy prepared statement cache (#40)
  - Add more db migration automation and use this for the travis setup (#41)
  - `db_version` table now stores integer ID and text for the version, not 
    postgres date (more robust for applying new migrations) (#41)
  - Add documentation on migration commands & utility scripts (#41)
  - Add tests for REST API & database operations (#41)
  - Add documentation & examples on tests (#41)

# fence # Release Notes

For: uc-cdis/fence

Notes since tag: 2.6.0

Notes to tag/commit: 3.2.4

Generated: 2019-07-10



## Dependency Updates
  - bump sqlalchemy 0.9.9 to 1.3.3 (#630)
  - bump userdatamodel 1.5.0 to 1.5.1 (#630)
  - bump authlib from 0.9 to 0.11 (#628)
  - bump userdatamodel to 1.4.3 (#621)
  - bump cirrus (#595)
  - bump userdatamodel (#595)
  - Upgrade PyYaml to 5.1 (#591)
  - Use the latest cirrus release (#586)
  - Get gen3cirrus from PyPI, bump to 0.3.1 (#583)
  - Bump storage-client to 0.2.2 (#583)

## Bug Fixes
  - fix exception when dbgap resources and user.yaml have a matching root level 
    resource without any subresources and create regression test (#656)
  - google-user-sa-validation calls dockerrun to start service now instead of 
    forcibly calling apache (was getting errors b/c fence is using nginx now) 
    (#654)
  - fix issue with service account registration where validation checks new 
    access *and* previous access when trying to update an SA (so if updating to 
    restrict to a subset of previous access, validation may fail and not allow 
    the update) (#651)
  - Re-add openssh back to image for sftp access to work correctly (#644)
  - fix error with logger if no user.yaml provided (#639)
  - can now successfully call `fence-create sync --sync_from_dbgap True` 
    without providing a valid `user.yaml` (e.g. just a dbgap sync) (#637)
  - Fix typos in exception handler (#626)
  - fix federated fence login endpoint jwt validation (#627)
  - Fix small bug of multipart upload endpoint. The bug makes a false alarm on 
    the last step of multipart completion. (#620)
  - fix 500 errors when creating a service account with prefix (#602)
  - Fixes bug where fence-config would not support some special characters 
    (#585)
  - fix google sa validation edge-case where monitor loses access, correctly 
    handle and log details (#582)

## New Features
  - dbgap syncing now updates resources in arborist (#641)
  - `SESSION_COOKIE_DOMAIN` is now configurable (#640)
  - Client policies can be managed in the user.yaml as long as the client 
    already exists in fence (#642)
  - use standard base image (#638)
  - Configure new clients with arborist policies using `--arborist` and 
    `--policies` flags for `fence-create` (#608)
  - Use arborist for authorization checks on downloading data files from 
    indexd, _as long as_ the `authz` field is present in the index record (#608)
  - swagger document for multipart upload presigned url (#616)
  - Allow setting policies for `anonymous` and `logged-in` groups in the 
    `user.yaml`. (#625)
  - Use arborist to check permission for indexd record upload/download on 
    records when supported (send `"rbac"` field from the indexd record to 
    arborist) (#606)
  - Set delete cascades in Fence db in general: now deleting a row in a parent 
    table will delete the appropriate child rows too. (#595)
  - Add delete-user endpoint to remove user and user-related data, both from 
    Fence db and from Google if applicable. (#595)
  - app engine default service account is an allowed type for SA registration 
    for Google data access (#615)
  - Implemented multipart upload with presigned url (#614)
  - optional `no_force_sign` argument to /data/download to suggest not to sign 
    the url if the data is public (#596)
  - Added dockerfile for deploying fence with shibboleth IdPs for login (#603)
  - Implements ORCID & Microsoft Organizations as IdP Options (#585)

## Improvements
  - dbgap sync will no longer create duplicate entries in arborist database for 
    user with lower & upper case name (#655)
  - service account validation will only verify that users on the Google 
    Project have access to the projects the *active* registered service account 
    have access to (in other words, expired service account project access 
    won't be checked since they don't actually have access to data) (#651)
  - fence will now consider authz field on indexd record to determine if a file 
    is public or not (for different signed url behavior). previously only 
    checked acl field (#653)
  - allow not providing a user.yaml (e.g. just a pure dbgap sync). previously 
    you had to pass an empty user.yaml (#641)
  - dbgap study to arborist resource namespace configuration (#641)
  - specify upstream idp to require user re-auth. caveat is some IdPs wouldn't 
    support it (#643)
  - The login endpoints now verify that the redirect provided is valid 
    according to fence: it redirects back to the Gen3 application, to an OAuth 
    client, or to some other approved URL from the configuration. (#540)
  - Deployment changes (#540)
  - Added optional new LOGIN_REDIRECT_WHITELIST config variable to allow for 
    redirecting to specific domains for login/logout. (#540)
  - Base class for different IDPs for Login (#593)
  - Update default configuration with details about setting up ORCID & 
    Microsoft OAuth 2 Clients (#593)
  - Better logging for sftp connections for dbgap syncing (#637)
  - filter SAWarning about not reflecting partial indices (#636)
  - Support providing alternative identity provider in oidc flow (#635)
  - use new gen3config instead of having all config code in fence (#592)
  - validate user.yaml files via gen3users tests before running usersync (#629)
  - Update user sync for compatibility with changes to arborist. (#613)
  - Policies now owned by arborist (#613)
  - Arborist needs (read-only) copy of users. (#613)
  - Add an unittest for the case users provide wrong code for the /authorize 
    endpoint (#623)
  - allowed service accounts for registration are now in configuration (#615)
  - Allowed scopes for user/client/session now in configuration instead of 
    hard-coded (#609)
  - Set log level based on config['DEBUG'] (#588)
  - Use PyYaml safe_load() instead of load() (#591)
  - User info endpoint will return policy list from arborist for that user, if 
    available. (#604)
  - will sign public Google storage object urls by default now using provided 
    or anonymous creds (better support programmatic access) (#596)
  - will sign public AWS S3 objects by default (with provided user creds or 
    anonymous user creds) UNLESS the entire bucket is configured as public 
    (#596)
  - don't use debian image for sftp/ssh, just apt install openssh-client (#597)
  - default to *not* changing the current Google SA naming convention in an env 
    (#594)
  - handle conversion to new Google SA naming convention gracefully if changed 
    (#594)
  - new GOOGLE_SERVICE_ACCOUNT_PREFIX for Google SA names (#594)
  - Simplify multi-tenant tests to use only one Fence instance and clarify what 
    is actually being tested. (#584)
  - Service accounts now have unique names per namespace by passing through 
    prefix used for Google groups (#590)

## Breaking Changes
  - remove `--verbose` option to `fence-create` CLI, prefers checking the 
    `DEBUG` value from config now to determine whether or not to output debug 
    logs (#647)
  - Users' RBAC policies are now owned by arborist, not fence, so the tables 
    are removed from fence/userdatamodel. (#608)
  - The usersync is updated to work specifically with the new arborist version. 
    (#608)
  - In general, this and following versions of fence should be deployed only 
    with 
    [arborist>=2.0.0](https://github.com/uc-cdis/arborist/releases/tag/2.0.0) 
    (#608)
  - Intended to work only with arborist >= 2.0 (using new database). Won't work 
    with older arborist API. (#613)
  - Remove (unused) RBAC blueprint (#606)
  - Questions: (#606)
  - stick with `"read-storage"`/`"write-storage"` ? (#606)

# indexd # Release Notes

For: uc-cdis/indexd

Notes since tag: 1.1.1

Notes to tag/commit: 02d6ed8d672137ee056faf019d562230b3acc348

Generated: 2019-07-10



## Deployment Changes
  - Add script to run for filling out records' `authz` fields based on the 
    `acl` fields. (#218)

## New Features
  - Add coveralls integration for code coverage analytics (#226)
  - Now Indexd calls Arborist for permission check (#215)
  - added new authz field (previously rbac field) (#214)
  - Changing from apache 2 to nginx (#213)
  - updating to uwsgi (#213)
  - Record now have a new `rbac` field (#209)

## Bug Fixes
  - Remove extra leading `/` in resource paths in migration (#221)
  - Fix log message (#221)
  - Make window size formatting string clearer (#221)

## Dependency Updates
  - bump sqlalchemy from 1.0.8 to 1.3.3 (#211)
  - bump sqlalchemy-utils from 0.32.21 to 0.33.11 (#211)

# peregrine # Release Notes

For: uc-cdis/peregrine

Notes since tag: 1.0.9

Notes to tag/commit: 1.3.0

Generated: 2019-07-10



## Dependency Updates
  - bump gen3dictionary to 2.0.0 (#136)
  - bump sqlalchemy 0.9.9 to 1.3.5 (#130)
  - bump psqlgraph (#130)
  - bump gen3datamodel (#130)
  - bump datamodelutils (#130)
  - bump dictionaryutils (#130)
  - bump gdcdictionary (#130)
  - bump authutils (#130)
  - bump pyyaml to 5.1 (#130)
  - remove flask-postgres-session (was unused) (#130)
  - bump sheepdog (#130)
  - point gen3datamodel to temporary branch until sqlalchemy and psqlgraph get 
    updated (#135)
  - bump indexclient to 1.5.7 (#135)
  - bump flaks-postgres-session to 0.1.4 (#135)
  - remove signpost from dev-requirements (#135)
  - Remove pyasn1-modules, urllib3, cirrus, userdatamodel, and fence from 
    dev-requirements (#131)
  - removed scipy, unnecessary (#110)

## Deployment Changes
  - look for INDEX_CLIENT instead of SIGNPOST in app.config (#135)
  - get INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST (#135)

## Bug Fixes
  - fix datasets regex which only match single digit index (#128)
  - Python base image has uwsgi configuration for timeout to return valid JSON 
    now (#127)
  - Fix bug when a data node contains an array field (#125)
  - transaction_log `response` field was always null (#119)
  - transaction_log `doc_size` field threw an error when the `doc` field was 
    not also queried (#119)

## Breaking Changes
  - removed redundant building steps (#110)

## Improvements
  - change the Peregrine /_version endpoint to just get the gdcdictionary 
    version programmatically, so that we can remove recently-broken lines in 
    the Dockerfile (#130)
  - looks for INDEX_CLIENT instead of SIGNPOST in app.config and gets 
    INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST--you must therefore use 
    the latest cloud automation or manually recreate your peregrine secrets 
    (#135)
  - stops importing and using signpost in testing, and stops calling index 
    client signpost where index client is already being used instead of 
    signpost (#135)
  - remove global harakiri setting (#133)
  - Now `quick_search: ""` is ignored for performance. (#126)
  - travis now runs all the tests (#119)

## New Features
  - handle filtering by boolean properties in queries (#124)
  - Implements /datasets/projects endpoint that has the same access control 
    mechanism as /datasets (#123)

# pidgin # Release Notes

For: uc-cdis/pidgin

Notes since tag: 1.0.0

Notes to tag/commit: a4aa1d95a09f573b1f9202e70d7bb2cad6798205

Generated: 2019-07-10



## Deployment Changes
  - use the latest version of the python 3 base image (#29)
  - The Dockerfile now uses an Alpine image (#24)

## Improvements
  - add schemaorg example to swagger documentation (#28)
  - Add Jenkinsfile (#27)
  - Use the image tag instead of master (#25)

## Dependency Updates
  - Bump PyYAML to 5.1 (#26)

# sheepdog # Release Notes

For: uc-cdis/sheepdog

Notes since tag: 1.1.8

Notes to tag/commit: d7023b4f19dcdc8dcb5b8b839660834e4facba6a

Generated: 2019-07-10



## Deployment Changes
  - look for INDEX_CLIENT instead of SIGNPOST in app.config (#291)
  - get INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST (#291)
  - Sheepdog will now create (or replace) the missing indexes during migration 
    (#259)
  - New unique indexes have been added to all nodes uc-cdis/gdcdatamodel#12 
    (#259)

## New Features
  - Accept consent codes during submission and include the consent codes in the 
    indexd record's `authz` field. (#288)

## Bug Fixes
  - Fixed a bug in Indexd API calling when base_url has subpath (#287)
  - Handle integrity Error when there are two transactions submit data to DB 
    (#282)
  - fix the parsing of asterisks in properties for TSV and JSON metadata 
    submission (#273)
  - Don't use lazy application initialization setting in uwsgi, which was 
    causing multiple workers to try to open the database simultaneously (and 
    fail if they couldn't). (#256)

## Dependency Updates
  - bump gdcdictionary to gen3dictionary 2.0.0 (#292)
  - bump sqlalchemy from 0.9.9 to 1.3.5 (#278)
  - bump dictionaryutils from 2.0.4 to 2.0.7 (#278)
  - bump psqlgraph to 2.0.2 (#278)
  - bump gen3datamodel to 2.0.2 (#278)
  - bump indexd from 1.0.8 to 1.1.2 (#278)
  - bump authutils to 3.1.1 (#278)
  - bump requests to 2.22.0 (#278)
  - add rbac-client (#278)
  - bump datamodelutils to 0.4.7 (#278)
  - remove signpost and signpostclient from requirements (#291)
  - Remove cirrus from dev-requirements (#284)
  - Remove fence from dev-requirements (#284)
  - Remove userdatamodel from dev-requirements (#284)
  - datamodelutils bumped to 0.4.5 (#280)
  - datamodelutils latest version (#277)
  - Upgrade PyYaml to 5.1 (#271)

## Breaking Changes
  - looks for INDEX_CLIENT instead of SIGNPOST in app.config and gets 
    INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST--you must therefore use 
    the latest cloud automation or manually recreate your sheepdog secrets 
    (#291)
  - removes the USE_SIGNPOST backwards-compatibility workarounds and testing, 
    since GDC forked sheepdog and signpost is dead (#291)
  - deprecate "related cases" caching--not a problem if CASE_CACHE was False 
    (#290)
  - removed redundant building steps (#263)
  - changed uwsgi socket location (#263)

## Improvements
  - stops importing and using signpost, and stops calling index client signpost 
    where index client is already being used instead of signpost (#291)
  - renames various vbbs and fns to not be signpost-specific, eg "signpost_obj" 
    to "file_record" (#291)
  - Added missing index to make submission faster (#280)
  - added unique indexes for uniqueKeys (#259)
  - Timeout is disabled for export endpoint (#275)
  - add tests for TSV and CSV submission (#273)
  - add tests for TSV and JSON submission with asterisks (#273)
  - Links are now case-insensitive (#272)
  - Use PyYaml safe_load() instead of load() (#271)

# portal # Release Notes

For: uc-cdis/data-portal

Notes since tag: 2.7.4

Notes to tag/commit: fd6be3020958c359fb9b78714fe68d22836f6687

Generated: 2019-07-10



## Deployment Changes
  - New manifest.json variable: logout_inactive_users. Defaults to true if not 
    provided. (#526)
  - https://github.com/uc-cdis/cloud-automation/pull/818 (#526)
  - enable source map tool so that developers could have better debugging under 
    dev mode (#514)

## New Features
  - Merges the file explorer with the data explorer (#547)
  - Use Hatchery to allow users to pick from Docker containers (#527)
  - Add support for external Fence (#542)
  - Windmill looks better on tablet/mobile (#519)
  - Implemented blocking table for authenticated but not authorized view (#517)
  - Utilized `ConnectFilter` from `Guppy` (#517)
  - Data explorer now supports tiered access by using `Guppy` (#517)
  - More relevant Explorer. (#522)
  - More relevant number on homepage for mickey (#521)
  - Use guppy for data explorer instead of arranger (#505)
  - Apps!! (#501)
  - Updated packages, most notably Webpack v4 (#491)
  - Adds configuration for chart colors (#507)
  - Entity Counts are now displayed accurately as chunks are submitted (#500)
  - Changing query from 10,000 to 20 (#499)
  - Toaster component (#498)

## Improvements
  - File explorer that uses ES index instead of slow graphQL queries (#547)
  - Better bar charts for guppy explorer with "show more"/"show less" buttons 
    (#537)
  - Revise some guppy explorer options (#537)
  - Add canine portal config (#537)
  - Updated BRAIN logo (#539)
  - Updated logo (#536)
  - Relevant homepage stats (#536)
  - Windmill is more usable on tablet/mobile (#519)
  - remove guppyConfig for now (#531)
  - Overall UI/UX improvement to meet design requirements for tiered access 
    data explorer page (#517)
  - remove useless post-install just to speed up local developing (#530)
  - Before starting, check if the homepage chart config in portal config is 
    correct (#529)
  - improve export to workspace performance (#520)
  - Text for HIV Classifier app is clearer (#516)
  - UI looks cleaner (#512)
  - Updating NIAID configuration for new explorer facets and export to 
    workspace button (#510)
  - DataSTAGE branding (#509)
  - Using the button component from UI library (#507)
  - Page won't time out (#499)

## Code Changes
  - > The SessionMonitor no longer logs out users. If a user has been inactive 
    and the config has logoutInactiveUsers == true, we just decline to refresh 
    their session and allow Fence to log them out. At this point, we start 
    using Sheepdog to check their auth status instead of Fence, so that we can 
    check their auth status without refreshing the access token. (#526)
  - > Users are allowed to keep a workspace tab open for the duration of the 
    Fence session lifetime without being logged out (likely 8 hours). We can't 
    detect user activity within the workspace iframe, so a solution to detect 
    their activity is not trivial. (Note that once a Jupyter pod is spawned, it 
    stays alive regardless of whether or not we redirect their browser to the 
    login page.) Allowing "inactivity" on this page will make it easier for 
    users to perform long-running analysis operations in a notebook overnight 
    (the redirect didn't work before anyway, because the browser displays that 
    "You have unsaved changes" popup which can be declined). (#526)
  - > The session is now updated every 5 minutes, rather than every 10 minutes. 
    If a user's auth has expired and the session is not updated, the user won't 
    know they've been logged out until they navigate to a new page (or until 
    they notice that pages are suddenly refusing to serve them data). 
    Increasing the updateSession frequency is helpful in this situation. (#526)

## Bug Fixes
  - Fix for issue where Guppy's downloadRawDataByTypeAndFilter() is returning 
    different data formats in different commons. (#551)
  - Guppy export to workspace flow was using incorrect manifest format and was 
    including entries with undefined object_ids, resulting in a 400 response 
    from the manifest service (#548)
  - For the data upload process, we were casting everything to a string. This 
    created issues when the required input was a number. Fixes to parse as an 
    when needed integer. (#545)
  - Also fixes UI bug with the floating table header on the Data Upload page 
    (#545)
  - Fixes some padding inconsistencies for the responsive layout (#544)
  - fix  index chart crash bug when less than 3 nodes (#543)
  - fixed manifest format for downloading by flatting its content (#541)
  - The old `download manifest` logic was replaced by a similar logic for 
    creating manifest for `export to workspace` (#538)
  - Fix a bug that guppy explorer's "export to workspace" button not enabled at 
    first time (#537)
  - When files are re-uploaded/edited and submitted again, submission status is 
    reset. Previously, errors persisted, even when corrected in the file. (#534)
  - fixed missing slash for query page (#532)
  - add default value for tier access limit for local script (#531)
  - > The query page now calls updateSession() before executing a query. This 
    fixes the bug where query results come back empty with a 200 response in 
    the case where the user's session has expired. (#526)
  - > The refreshSession function now hits /user/user instead of just /user, so 
    that we can notify the user with the ReduxAuthTimeoutPopup if their session 
    is over (/user is public, /user/user is not). (#526)
  - Makes charts even width and not overflow in explorer, no overflow in facet 
    texts, and puts buttons on login page in column flow (#524)
  - fix the error filter to get right error entities for submission result 
    (#518)
  - make submission status shows the overall status (#518)
  - add arranger query limit to first 10000 to avoid err response (#515)
  - Empty lines will not be included in chunks now for submission (#508)
  - Page no longer jumps, as the iframe no longer expands enough to scroll. 
    (#506)
  - Updated Brain to be acronym (#504)
  - Entity Counts displayed accurately. (#500)
  - Total node counts now updated accurately after large submissions (#500)

# spark # Release Notes

For: uc-cdis/gen3-spark

Notes since tag: 1.0.0

Notes to tag/commit: 00ef588fd7d64415afe396bc754a6b39d20d7638

Generated: 2019-07-10



# tube # Release Notes

For: uc-cdis/tube

Notes since tag: 0.1.9

Notes to tag/commit: 0.3.7

Generated: 2019-07-10



## New Features
  - follow_up document for niaid (#73)
  - Dictionary of properties with key as `(doc_name, prop_name)` (#73)
  - sliding window (#71)
  - min/max aggregation (#71)
  - File can belong to multiple cases (#68)
  - File can connect directly to project, not case (#68)
  - Support one file belongs to multiple cases in file index (#67)
  - Forced running etl without new data (#66)
  - Facet for DCP (#61)

## Bug Fixes
  - fix backward compatible for arranger index (#73)
  - fix bug create type for `auth_resource_path` (#73)
  - File with `case_id` null (#68)
  - `data_format` and `data_type` empty (#68)
  - missing `category` field (#62)
  - There is a bug in timestamp feature branch that used hard-code index name 
    called `etl`. It is fixed by this branch (#58)

