### PR TITLE
chore(nci-crdc-fence): update to 3.2.4.2

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:3.2.4.1",
+    "fence": "quay.io/cdis/fence:3.2.4.2",
     "arborist": "quay.io/cdis/arborist:2.0.6",
     "google-sa-validation": "placeholder",
     "indexd": "quay.io/cdis/indexd:1.1.4",


### PR DESCRIPTION
diff:
https://github.com/uc-cdis/fence/commit/2d47da3fa8f24a2f01f3a78b03be2e47eb874752 

relates to PXP-3384, fix endpoint for patching service accounts so they actually get added to gbags