### PR TITLE
Fix(Update pelican version in staging.theanvil.io)

### DIFF
--- a/staging.theanvil.io/manifest.json
+++ b/staging.theanvil.io/manifest.json
@@ -116,7 +116,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican:0.1.5",
+        "image": "quay.io/cdis/pelican:0.1.6",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
PFB export / Terra export jobs were erroring out in staging.theanvil.io, most likely cause is an issue with pelican version that sower is using.