### PR TITLE
fix(stage): tube version update

### DIFF
--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -18,7 +18,7 @@
     "portal": "quay.io/cdis/data-portal:2.19.1",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
-    "tube": "quay.io/cdis/tube:0.3.10",
+    "tube": "quay.io/cdis/tube:0.3.14",
     "guppy": "quay.io/cdis/guppy:0.3.0",
     "sower": "quay.io/cdis/sower:0.3.0",
     "hatchery": "quay.io/cdis/hatchery:0.1.0",


### PR DESCRIPTION
* Update `tube` to latest version `0.3.14` for fixes for Centralized Auth.