### PR TITLE
NDE microbiome: copy versions from QA

### DIFF
--- a/microbiome.niaiddata.org/manifest.json
+++ b/microbiome.niaiddata.org/manifest.json
@@ -8,7 +8,6 @@
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "guppy": "quay.io/cdis/guppy:master",
     "indexd": "quay.io/cdis/indexd:master",
     "manifestservice": "quay.io/cdis/manifestservice:master",
     "peregrine": "quay.io/cdis/peregrine:2.1.1",

--- a/microbiome.niaiddata.org/manifest.json
+++ b/microbiome.niaiddata.org/manifest.json
@@ -4,29 +4,28 @@
     "That's all I have to say"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:1.2.1",
-    "fence": "quay.io/cdis/fence:fix_niaddata",
-    "indexd": "quay.io/cdis/indexd:1.1.2",
+    "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "peregrine": "quay.io/cdis/peregrine:1.2.1",
-    "pidgin": "quay.io/cdis/pidgin:1.1.0",
-    "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.12",
-    "portal": "quay.io/cdis/data-portal:2.20.1",
+    "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "spark": "quay.io/cdis/gen3-spark:1.0.0",
-    "manifestservice": "quay.io/cdis/manifestservice:0.1.1",
-    "tube": "quay.io/cdis/tube:0.3.15"
-  },
-  "jupyterhub": {
-    "enabled": "no"
+    "guppy": "quay.io/cdis/guppy:master",
+    "indexd": "quay.io/cdis/indexd:master",
+    "manifestservice": "quay.io/cdis/manifestservice:master",
+    "peregrine": "quay.io/cdis/peregrine:2.1.1",
+    "pidgin": "quay.io/cdis/pidgin:1.2.0",
+    "portal": "quay.io/cdis/data-portal:2.20.6",
+    "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
+    "sheepdog": "quay.io/cdis/sheepdog:2.1.1",
+    "sower": "quay.io/cdis/sower:master",
+    "spark": "quay.io/cdis/gen3-spark:master",
+    "tube": "quay.io/cdis/tube:master",
+    "dashboard": "quay.io/cdis/gen3-statics:master"
   },
   "global": {
     "environment": "niaiddata",
     "hostname": "microbiome.niaiddata.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:636151780898:certificate/07014a42-0e88-40f3-bc84-6ae664036fec",
-    "dictionary_url": "https://dictionary-artifacts.s3.amazonaws.com/microbiome_datadictionary/1.0.1/schema.json",
+    "dictionary_url": "https://dictionary-artifacts.s3.amazonaws.com/microbiome_datadictionary/1.1.0/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-niaiddata-gen3",
     "logs_bucket": "logs-niaiddata-gen3",
@@ -43,6 +42,32 @@
     "netpolicy": "off",
     "cookie_domain": "niaiddata.org",
     "des_namespace": "default"
+  },
+  "arborist": {
+    "deployment_version": "2"
+  },
+  "indexd": {
+    "arborist": "true"
+  },
+  "jupyterhub": {
+    "enabled": "no"
+  },
+  "sower": {
+    "name": "pelican-export",
+    "container": {
+      "name": "job-task",
+      "image": "quay.io/cdis/pelican:master",
+      "pull_policy": "always",
+      "env": [],
+      "cpu-limit": "1",
+      "memory-limit": "12Gi"
+    },
+    "restart_policy": "never"
+  },
+  "ssjdispatcher": {
+    "job_images": {
+      "indexing": "quay.io/cdis/indexs3client:master"
+    }
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
update the prod manifest to be similar to the QA manifest
Bump peregrine and sheepdog for the arborist integration fix
The services that are pinned to master are the ones we don't use. we should probably pin or remove them but we'll do that in QA first