### PR TITLE
fix(guppy): configuration for alias for array-config

### DIFF
--- a/aids.niaiddata.org/manifest.json
+++ b/aids.niaiddata.org/manifest.json
@@ -67,8 +67,7 @@
         "type": "file"
       }
     ],
-    "config_index": "daids-array-config",
+    "config_index": "daids_array-config",
     "auth_filter_field": "auth_resource_path"
   }
 }
-

--- a/flu.niaiddata.org/manifest.json
+++ b/flu.niaiddata.org/manifest.json
@@ -64,8 +64,7 @@
         "type": "file"
       }
     ],
-    "config_index": "flu-array-config",
+    "config_index": "flu_array-config",
     "auth_filter_field": "auth_resource_path"
   }
 }
-

--- a/tb.niaiddata.org/manifest.json
+++ b/tb.niaiddata.org/manifest.json
@@ -64,7 +64,7 @@
         "type": "file"
       }
     ],
-    "config_index": "tb-array-config",
+    "config_index": "tb_array-config",
     "auth_filter_field": "auth_resource_path"
   }  
 }


### PR DESCRIPTION
The configuration for Guppy should use underscore in the `array-config`, like this:

```
tb_array-config
```

The dash version `tb-array-config` is an alias for latest version of array config only for `tb` part in `etlMapping.yaml`. Same for `tb_file-array-config` and `tb_follow_up-array-config`.