### PR TITLE
chore(stage): reduce memory requirements for Pelican job

### DIFF
--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -75,8 +75,8 @@
             "subPath": "creds.json"
           }
         ],
-        "cpu-limit": "1",
-        "memory-limit": "12Gi"
+        "cpu-limit": "2",
+        "memory-limit": "6Gi"
       },
       "volumes": [
         {


### PR DESCRIPTION
# Changes

* The memory footprint for Pelican job to export all the data doesn't use more than 50% of memory (see image). Reducing the memory requirements with slight increase in CPU can improve the runtime.

<img width="1357" alt="Screen Shot 2019-10-16 at 4 18 19 PM" src="https://user-images.githubusercontent.com/8220926/66959731-9e831d00-f030-11e9-9456-b08718c1db62.png">
