### PR TITLE
fix(dcf): pidgin 1.2.0 - match production

### DIFF
--- a/nci-crdc.datacommons.io/manifest.json
+++ b/nci-crdc.datacommons.io/manifest.json
@@ -12,7 +12,7 @@
     "google-sa-validation": "placeholder",
     "indexd": "quay.io/cdis/indexd:2.1.0",
     "peregrine": "quay.io/cdis/peregrine:1.0.5",
-    "pidgin": "quay.io/cdis/pidgin:1.0.0",
+    "pidgin": "quay.io/cdis/pidgin:1.2.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
     "sheepdog": "quay.io/cdis/sheepdog:1.1.6",
     "portal": "quay.io/cdis/data-portal:2.2.5",


### PR DESCRIPTION
we're running pidgin 1.2.0 in prod - just syncing up github