### PR TITLE
fix(aids): remove manifest button in explorer

### DIFF
--- a/aids.niaiddata.org/portal/gitops.json
+++ b/aids.niaiddata.org/portal/gitops.json
@@ -248,17 +248,7 @@
         "title": "Download All Clinical",
         "leftIcon": "user",
         "rightIcon": "download",
-        "fileName": "clinical.json",
-        "dropdownId": "download"
-      },
-      {
-        "enabled": true,
-        "type": "manifest",
-        "title": "Download Manifest",
-        "leftIcon": "datafile",
-        "rightIcon": "download",
-        "fileName": "manifest.json",
-        "dropdownId": "download"
+        "fileName": "clinical.json"
       },
       {
         "enabled": true,


### PR DESCRIPTION
remove manifest button from data explorer since there's already a same button in file explorer. Also AIDS commons doesn't have any file for now. 