### PR TITLE
fix(aids): portal to 2.22.6

### DIFF
--- a/aids.niaiddata.org/manifest.json
+++ b/aids.niaiddata.org/manifest.json
@@ -12,7 +12,7 @@
     "pidgin": "quay.io/cdis/pidgin:1.1.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
     "sheepdog": "quay.io/cdis/sheepdog:1.1.12",
-    "portal": "quay.io/cdis/data-portal:2.22.4",
+    "portal": "quay.io/cdis/data-portal:2.22.6",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",


### PR DESCRIPTION
Bump AIDS portal to 2.22.6, this version fixes HIV app PTC criteria. 