### PR TITLE
chore(bump up indexd for latest version)

### DIFF
--- a/ibdgc.datacommons.io/manifest.json
+++ b/ibdgc.datacommons.io/manifest.json
@@ -7,7 +7,7 @@
     "arborist": "quay.io/cdis/arborist:2.3.2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "quay.io/cdis/fence:4.13.1",
-    "indexd": "quay.io/cdis/indexd:1.1.4",
+    "indexd": "quay.io/cdis/indexd:2.6.0",
     "peregrine": "quay.io/cdis/peregrine:1.3.0",
     "pidgin": "quay.io/cdis/pidgin:1.2.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",


### PR DESCRIPTION
We might need to do indexd migration at some point. 
This shouldn't impact function on the commons though. 