### PR TITLE
feat(staging.datastage.io): pelican version with topological order

### DIFF
--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -38,7 +38,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:0.2.2",
+        "image": "quay.io/cdis/pelican-export:0.2.3",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
* Updates Pelican to version `0.2.3` to make record in a PFB in topological order (from program down to all the other dictionary nodes).