### PR TITLE
feat(datastage_release): Update fence + autoscaler config for new presigned-url-fence cluster

### DIFF
--- a/internalstaging.datastage.io/manifest.json
+++ b/internalstaging.datastage.io/manifest.json
@@ -9,7 +9,7 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2.3.2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:4.13.2",
+    "fence": "quay.io/cdis/fence:4.13.3",
     "indexd": "quay.io/cdis/indexd:2.6.1",
     "peregrine": "quay.io/cdis/peregrine:2.1.1",
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
@@ -342,8 +342,14 @@
     },
     "fence": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 5,
+      "max": 15,
+      "targetCpu": 40
+    },
+    "presigned-url-fence": {
+      "strategy": "auto",
+      "min": 20,
+      "max": 25,
       "targetCpu": 40
     },
     "indexd": {


### PR DESCRIPTION
The load testing exercises revealed certain RPS thresholds in which fence would struggle to produce responses with a reasonable latency. In order to avoid a scenario where fence would still receive a surge of requests while being overwhelmed, this new fence image allows the cluster admin to leverage an Nginx config that can prevent the unnecessary workload from reaching the Python engine.
This is all managed through an optional variable (`NGINX_RATE_LIMIT `) that is added to the env block of the k8s deployment descriptor.

On top of that, as a measure to protect the system in case the cluster gets overwhelmed with too many PreSigned URL requests (which is our most expensive operation), we are splitting our current fence deployment in 2: This manifest change also includes the initial autoscaler configuration for this new `presigned-url-fence` cluster.
That will also allow us to control its Nginx rate limit config for performance tuning purposes, without affecting all the other interactions