### PR TITLE
Release/datastage prod 2019 q4 test

### DIFF
--- a/internalstaging.datastage.io/manifest.json
+++ b/internalstaging.datastage.io/manifest.json
@@ -38,7 +38,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican:0.2.3",
+        "image": "quay.io/cdis/pelican-export:0.2.3",
         "pull_policy": "Always",
         "env": [
           {

--- a/internalstaging.datastage.io/manifest.json
+++ b/internalstaging.datastage.io/manifest.json
@@ -9,7 +9,7 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2.3.2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:4.13.2",
+    "fence": "quay.io/cdis/fence:4.13.3",
     "indexd": "quay.io/cdis/indexd:2.6.1",
     "peregrine": "quay.io/cdis/peregrine:2.1.1",
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
@@ -342,8 +342,14 @@
     },
     "fence": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 5,
+      "max": 15,
+      "targetCpu": 40
+    },
+    "presigned-url-fence": {
+      "strategy": "auto",
+      "min": 20,
+      "max": 25,
       "targetCpu": 40
     },
     "indexd": {

--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -9,8 +9,8 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2.3.2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:4.11.0",
-    "indexd": "quay.io/cdis/indexd:2.1.0",
+    "fence": "quay.io/cdis/fence:4.13.3",
+    "indexd": "quay.io/cdis/indexd:2.6.1",
     "peregrine": "quay.io/cdis/peregrine:2.1.1",
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
@@ -105,7 +105,7 @@
     "sidecar": {
       "cpu-limit": "1.0",
       "memory-limit": "256Mi",
-      "image": "quay.io/cdis/gen3fuse-sidecar:chore_sidecar",
+      "image": "quay.io/cdis/gen3fuse-sidecar:0.1.4",
       "env": {
         "NAMESPACE":"staging",
         "HOSTNAME": "staging.datastage.io"
@@ -300,7 +300,7 @@
     "environment": "stagingdatastage",
     "hostname": "staging.datastage.io",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/4081369d-6d60-44ff-aa07-11bac3618a9a",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.7/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.8/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",
@@ -341,6 +341,12 @@
       "targetCpu": 40
     },
     "fence": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
+    },
+    "presigned-url-fence": {
       "strategy": "auto",
       "min": 2,
       "max": 4,


### PR DESCRIPTION
Investigating issue with a gen3-qa test:
`gen3-qa/suites/google/googleServiceAccountKeyTest.js`

The `SA key removal job test: remove expired creds that do not exist in google @reqGoogle` scenario was failing consistently (multiple attempts in diff jenkins namespaces) on Dec 31 2019.