### PR TITLE
fix(data-staging.brain): scale down

### DIFF
--- a/data-staging.braincommons.org/manifest.json
+++ b/data-staging.braincommons.org/manifest.json
@@ -180,8 +180,8 @@
   "scaling": {
     "arborist": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 1,
+      "max": 1,
       "targetCpu": 40
     },
     "portal": {
@@ -192,8 +192,8 @@
     },
     "fence": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 1,
+      "max": 1,
       "targetCpu": 40
     },
     "indexd": {
@@ -206,6 +206,12 @@
       "strategy": "auto",
       "min": 2,
       "max": 4,
+      "targetCpu": 40
+    },
+    "presigned-url-fence": {
+      "strategy": "auto",
+      "min": 1,
+      "max": 1,
       "targetCpu": 40
     },
     "revproxy": {


### PR DESCRIPTION
to free up db connections
data-staging uses the same db servers as prod - scaling down to give prod a little more head room after scaling up fence to run 20+ url-signers
