### PR TITLE
make staging match prod

### DIFF
--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -301,7 +301,7 @@
     "environment": "stagingdatastage",
     "hostname": "staging.datastage.io",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/4081369d-6d60-44ff-aa07-11bac3618a9a",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.8/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.9/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",

--- a/staging.datastage.io/manifest.json
+++ b/staging.datastage.io/manifest.json
@@ -9,13 +9,13 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2.3.2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:4.13.3",
+    "fence": "quay.io/cdis/fence:4.13.4",
     "indexd": "quay.io/cdis/indexd:2.6.1",
-    "peregrine": "quay.io/cdis/peregrine:2.1.1",
+    "peregrine": "quay.io/cdis/peregrine:3.0.0",
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.10",
-    "portal": "quay.io/cdis/data-portal:2.22.6",
+    "sheepdog": "quay.io/cdis/sheepdog:3.0.0",
+    "portal": "quay.io/cdis/data-portal:2.22.10",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.18",
@@ -24,7 +24,8 @@
     "hatchery": "quay.io/cdis/hatchery:0.1.0",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
     "wts": "quay.io/cdis/workspace-token-service:0.2.0",
-    "manifestservice": "quay.io/cdis/manifestservice:0.2.0"
+    "manifestservice": "quay.io/cdis/manifestservice:0.2.0",
+    "dashboard": "quay.io/cdis/gen3-statics:1.0.0"
   },
   "google": {
     "enabled": "yes"
@@ -38,7 +39,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:0.2.3",
+        "image": "quay.io/cdis/pelican-export:0.3.2",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
sheepdog

- Fix Travis coverage reports (combine the results of all 3 tests into one coverage report). (#314)
- ARBORIST_URL environment variable replaces broken default ARBORIST config variable (#304)
- Optional configuration variable ARBORIST (arborist base URL) (#298)
- Requires Arborist to be deployed (#298)
- look for INDEX_CLIENT instead of SIGNPOST in app.config (#291)
- get INDEX_CLIENT_HOST env var instead of SIGNPOST_HOST (#291)