### PR TITLE
Terra export warning in BDCat Preprod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -15,7 +15,7 @@
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
     "sheepdog": "quay.io/cdis/sheepdog:3.0.0",
-    "portal": "quay.io/cdis/data-portal:2.24.2",
+    "portal": "quay.io/cdis/data-portal:2.24.3",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.18",

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -408,6 +408,7 @@
         "rightIcon": "download"
       }
     ],
-    "dropdowns": {}
+    "dropdowns": {},
+    "terraExportWarning": { "subjectThreshold": 14000 }
   }
 }


### PR DESCRIPTION
- Update portal version, add configuration enabling Terra Export Warning above 14,000 subjects.

Test plan added here: https://github.com/uc-cdis/gen3-qa/pull/237