### PR TITLE
fix(staging.bdc): Update Portal version for Terra template url

### DIFF
--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -15,7 +15,7 @@
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
     "sheepdog": "quay.io/cdis/sheepdog:3.0.0",
-    "portal": "quay.io/cdis/data-portal:2.24.2",
+    "portal": "quay.io/cdis/data-portal:2.24.3",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.18",


### PR DESCRIPTION
- Fixes an earlier commit which added configuration for terra template url but did not add correct portal version (earlier commit added portal v.2.24.2, but we really wanted v.2.24.3)

