### PR TITLE
Release(bdc): Add Terra Export Warning

### DIFF
--- a/gen3.datastage.io/manifest.json
+++ b/gen3.datastage.io/manifest.json
@@ -15,7 +15,7 @@
     "pidgin": "quay.io/cdis/pidgin:1.0.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
     "sheepdog": "quay.io/cdis/sheepdog:3.0.0",
-    "portal": "quay.io/cdis/data-portal:2.24.2",
+    "portal": "quay.io/cdis/data-portal:2.24.3",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:1.0.0",
     "tube": "quay.io/cdis/tube:0.3.18",

--- a/gen3.datastage.io/portal/gitops.json
+++ b/gen3.datastage.io/portal/gitops.json
@@ -408,6 +408,7 @@
         "rightIcon": "download"
       }
     ],
-    "dropdowns": {}
+    "dropdowns": {},
+    "terraExportWarning": { "subjectThreshold": 14000 }
   }
 }

--- a/gen3.datastage.io/portal/gitops.json
+++ b/gen3.datastage.io/portal/gitops.json
@@ -408,7 +408,7 @@
         "rightIcon": "download"
       }
     ],
-    "dropdowns": {},
-    "terraExportWarning": { "subjectThreshold": 14000 }
-  }
+    "dropdowns": {}
+  },
+  "terraExportWarning": { "subjectThreshold": 14000 }
 }


### PR DESCRIPTION
- Bump portal to 2.24.3 and include configuration for Terra Export warning feature. Warn users exporting cohorts >= 14000 subjects to Terra that their export may fail.

