### PR TITLE
feat(download): no dl buttons in BDC preprod data explorer

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -241,30 +241,7 @@
         "ldl"
       ]
     },
-    "dropdowns": {
-      "download": {
-        "title": "Download"
-      }
-    },
     "buttons": [
-      {
-        "enabled": true,
-        "type": "data",
-        "title": "Download All Clinical",
-        "leftIcon": "user",
-        "rightIcon": "download",
-        "fileName": "clinical.json",
-        "dropdownId": "download"
-      },
-      {
-        "enabled": true,
-        "type": "manifest",
-        "title": "Download Manifest",
-        "leftIcon": "datafile",
-        "rightIcon": "download",
-        "fileName": "manifest.json",
-        "dropdownId": "download"
-      },
       {
         "enabled": true,
         "type": "export",


### PR DESCRIPTION
For https://ctds-planx.atlassian.net/browse/PXP-5279

- Remove download buttons from BDCat data explorer preprod.

