### PR TITLE
Disable download buttons in Explorer

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -241,14 +241,9 @@
         "ldl"
       ]
     },
-    "dropdowns": {
-      "download": {
-        "title": "Download"
-      }
-    },
     "buttons": [
       {
-        "enabled": true,
+        "enabled": false,
         "type": "data",
         "title": "Download All Clinical",
         "leftIcon": "user",
@@ -257,7 +252,7 @@
         "dropdownId": "download"
       },
       {
-        "enabled": true,
+        "enabled": false,
         "type": "manifest",
         "title": "Download Manifest",
         "leftIcon": "datafile",


### PR DESCRIPTION
- Disable Download Clinical and Download Manifest buttons in the Data Explorer

