### PR TITLE
chore/anvil_dict:update dict release

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -31,7 +31,7 @@
     "environment": "anvilstaging",
     "hostname": "internalstaging.theanvil.io",
     "revproxy_arn": "arn:aws:acm:us-east-1:474789003679:certificate/9fd731e3-3366-4bd0-a3ef-0453dc07289a",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/anvil/1.1.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/anvil/1.1.3/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-anvilstaging-gen3",
     "logs_bucket": "logs-anvilstaging-gen3",


### PR DESCRIPTION
update the dictionary release to 1.1.3 for internal staging anvil