### PR TITLE
chore(brain-indexd-scaling): bumped up minimum indexd replicas and lo…

### DIFF
--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -149,7 +149,7 @@
     "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.0.1/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
-    "dispatcher_job_num": "10",
+    "dispatcher_job_num": "5",
     "sync_from_dbgap": "False",
     "public_datasets": true,
     "tier_access_level": "regular",
@@ -198,8 +198,8 @@
     },
     "indexd": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 3,
+      "max": 6,
       "targetCpu": 40
     },
     "peregrine": {


### PR DESCRIPTION
Bumped up indexd replicas and lowered max concurrent indexing jobs to relieve stress from indexd during indexing, which potentially caused indexing jobs to fail.

