### PR TITLE
chore(qa): Update CanineDC with Gen3 March Release

### DIFF
--- a/caninedc.org/manifest.json
+++ b/caninedc.org/manifest.json
@@ -7,7 +7,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.03",
+    "arborist": "quay.io/cdis/arborist:2.0.0",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "quay.io/cdis/fence:2020.03",
     "indexd": "quay.io/cdis/indexd:2020.03",

--- a/caninedc.org/manifest.json
+++ b/caninedc.org/manifest.json
@@ -7,24 +7,24 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:1.2.1",
+    "arborist": "quay.io/cdis/arborist:2020.03",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2.8.2",
-    "indexd": "quay.io/cdis/indexd:1.1.1",
-    "peregrine": "quay.io/cdis/peregrine:1.2.1",
-    "pidgin": "quay.io/cdis/pidgin:1.1.0",
-    "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.12",
-    "portal": "quay.io/cdis/data-portal:2.12.2",
+    "fence": "quay.io/cdis/fence:2020.03",
+    "indexd": "quay.io/cdis/indexd:2020.03",
+    "peregrine": "quay.io/cdis/peregrine:2020.03",
+    "pidgin": "quay.io/cdis/pidgin:2020.03",
+    "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
+    "sheepdog": "quay.io/cdis/sheepdog:2020.03",
+    "portal": "quay.io/cdis/data-portal:2020.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "spark": "quay.io/cdis/gen3-spark:1.0.0",
-    "wts": "quay.io/cdis/workspace-token-service:0.1.0",
-    "manifestservice": "quay.io/cdis/manifestservice:0.1.1",
-    "tube": "quay.io/cdis/tube:0.3.15",
-    "guppy": "quay.io/cdis/guppy:0.3.0",
-    "sower": "quay.io/cdis/sower:0.3.0",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:0.0.5"
+    "spark": "quay.io/cdis/gen3-spark:2020.03",
+    "wts": "quay.io/cdis/workspace-token-service:2020.03",
+    "manifestservice": "quay.io/cdis/manifestservice:2020.03",
+    "tube": "quay.io/cdis/tube:2020.03",
+    "guppy": "quay.io/cdis/guppy:2020.03",
+    "sower": "quay.io/cdis/sower:2020.03",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.03"
   },
   "sower": [
     {
@@ -32,7 +32,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican:0.3.2",
+        "image": "quay.io/cdis/pelican-export:2020.03",
         "pull_policy": "Always",
         "env": [
           {
@@ -94,7 +94,7 @@
   ],
   "jupyterhub": {
     "enabled": "yes",
-    "sidecar": "quay.io/cdis/gen3fuse-sidecar:0.1.2",
+    "sidecar": "quay.io/cdis/gen3fuse-sidecar:2020.03",
     "containers": [
                   {
                     "name": "Bioinfo - Python/R",

--- a/caninedc.org/manifest.json
+++ b/caninedc.org/manifest.json
@@ -7,7 +7,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2.0.0",
+    "arborist": "quay.io/cdis/arborist:2020.03",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "quay.io/cdis/fence:2020.03",
     "indexd": "quay.io/cdis/indexd:2020.03",
@@ -25,6 +25,9 @@
     "guppy": "quay.io/cdis/guppy:2020.03",
     "sower": "quay.io/cdis/sower:2020.03",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.03"
+  },
+  "arborist": {
+    "deployment_version": "2"
   },
   "sower": [
     {


### PR DESCRIPTION
Replicated from:
https://github.com/uc-cdis/cdis-manifest/tree/master/releases/2020/03