### PR TITLE
Fix css issue in prod footer

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
@@ -55,7 +55,7 @@
   background-color: #000;
 }
 
-.footer__nav {
+.footer-container {
   background-color: #000;
 }
 


### PR DESCRIPTION
- A code change in portal changed the class name that's required to override portal's styles in gitops.css.