### PR TITLE
chore(qa): Set Auto-Scaling config for the Metadata Service

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -158,6 +158,12 @@
       "min": 2,
       "max": 4,
       "targetCpu": 40
+    },
+    "metadata": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 5,
+      "targetCpu": 40
     }
   }
 }

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -207,6 +207,12 @@
       "min": 2,
       "max": 4,
       "targetCpu": 40
+    },
+    "metadata": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 5,
+      "targetCpu": 40      
     }
   }
 }


### PR DESCRIPTION
Bumping up number of replicas for MDS to avoid SPOF.