### PR TITLE
(PXP-5661): Add PRIVACY_POLICY_URL to BDCat preprod public fence config

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -1,0 +1,7 @@
+########################################################################################
+#                               OPTIONAL CONFIGURATIONS                                #
+########################################################################################
+
+# For displaying a privacy policy to users, we can either link to the URL specified by
+# PRIVACY_POLICY_URL, or default to the `static/privacy_policy.md` file in fence.
+PRIVACY_POLICY_URL: 'https://biodatacatalyst.nhlbi.nih.gov/privacy/'


### PR DESCRIPTION
Jira issue: https://ctds-planx.atlassian.net/browse/PXP-5661

Updates the privacy policy link in the `oauth2/authorize` webpage served by fence.