### PR TITLE
COVID19: Show arborist resources on profile page

### DIFF
--- a/covid19.datacommons.io/manifest.json
+++ b/covid19.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "peregrine": "quay.io/cdis/peregrine:2020.03",
     "pidgin": "quay.io/cdis/pidgin:2020.03",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.03",
+    "sheepdog": "quay.io/cdis/sheepdog:4.0.0",
     "portal": "quay.io/cdis/data-portal:2.24.8",
     "tube": "quay.io/cdis/tube:2020.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",

--- a/covid19.datacommons.io/portal/gitops.json
+++ b/covid19.datacommons.io/portal/gitops.json
@@ -320,5 +320,7 @@
         { "field": "subject_id", "name": "Subject" }
       ]
     }
-  }
+  },
+  "showArboristAuthzOnProfile": true,
+  "showFenceAuthzOnProfile": false
 }


### PR DESCRIPTION
- Show arborist resources on profile page instead of Fence projects, since we use arborist in the user.yaml
- Use sheepdog 4.0.0 to be able to use program/project CRUD arborist policies