### PR TITLE
chore(WAF): Tweak auto-scaling config. for revproxy/WAF in DCF environments

### DIFF
--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -25,7 +25,8 @@
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
     "wts": "quay.io/cdis/workspace-token-service:master",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:0.0.6",
-    "manifestservice": "quay.io/cdis/manifestservice:master"
+    "manifestservice": "quay.io/cdis/manifestservice:master",
+    "metadata": "quay.io/cdis/metadata-service:v1.2.0"
   },
   "peregrine": {
     "sidecar": "True"

--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -65,5 +65,43 @@
       }
     ],
     "auth_filter_field": "auth_resource_path"
+  },
+  "scaling": {
+    "arborist": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
+    },
+    "fence": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
+    },
+    "presigned-url-fence": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 10,
+      "targetCpu": 40
+    },
+    "indexd": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
+    },
+    "revproxy": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 6,
+      "targetCpu": 40
+    },
+    "metadata": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 5,
+      "targetCpu": 40
+    }
   }
 }

--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -25,8 +25,7 @@
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
     "wts": "quay.io/cdis/workspace-token-service:master",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:0.0.6",
-    "manifestservice": "quay.io/cdis/manifestservice:master",
-    "metadata": "quay.io/cdis/metadata-service:v1.2.0"
+    "manifestservice": "quay.io/cdis/manifestservice:master"
   },
   "peregrine": {
     "sidecar": "True"
@@ -96,12 +95,6 @@
       "strategy": "auto",
       "min": 2,
       "max": 6,
-      "targetCpu": 40
-    },
-    "metadata": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 5,
       "targetCpu": 40
     }
   }

--- a/nci-crdc-demo.datacommons.io/manifest.json
+++ b/nci-crdc-demo.datacommons.io/manifest.json
@@ -65,37 +65,5 @@
       }
     ],
     "auth_filter_field": "auth_resource_path"
-  },
-  "scaling": {
-    "arborist": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 4,
-      "targetCpu": 40
-    },
-    "fence": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 4,
-      "targetCpu": 40
-    },
-    "presigned-url-fence": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 10,
-      "targetCpu": 40
-    },
-    "indexd": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 4,
-      "targetCpu": 40
-    },
-    "revproxy": {
-      "strategy": "auto",
-      "min": 2,
-      "max": 6,
-      "targetCpu": 40
-    }
   }
 }

--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -147,6 +147,12 @@
       "max": 4,
       "targetCpu": 40
     },
+    "presigned-url-fence": {
+      "strategy": "auto",
+      "min": 2,
+      "max": 10,
+      "targetCpu": 40
+    },
     "indexd": {
       "strategy": "auto",
       "min": 2,
@@ -156,7 +162,7 @@
     "revproxy": {
       "strategy": "auto",
       "min": 2,
-      "max": 4,
+      "max": 6,
       "targetCpu": 40
     },
     "metadata": {

--- a/nci-crdc.datacommons.io/manifest.json
+++ b/nci-crdc.datacommons.io/manifest.json
@@ -76,7 +76,7 @@
     "revproxy": {
       "strategy": "auto",
       "min": 2,
-      "max": 4,
+      "max": 10,
       "targetCpu": 40
     }
   }


### PR DESCRIPTION
Now that nginx / WAF has been deployed to DCF staging environments, we should also tweak the auto-scaling configuration to enable cluster elasticity in case of a surge of requests.