### PR TITLE
fix(qa): Set correct shebang for pre-commit hook script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 git_diff=($( git diff --name-only origin/master | tr "\n" " "))
 


### PR DESCRIPTION
This is causing issues with some pygithub automation.