### PR TITLE
(PXP-5598): Add fix for orange file button

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
@@ -31,6 +31,14 @@
   border: 1px solid black;
 }
 
+/* fix for hard-coded orange button on File download page */
+.button-primary-orange {
+  background-color: var(--primary-color);
+}
+.button-primary-orange:hover {
+  background-color: var(--secondary-color);
+}
+
 /* Nav Bars and Footer */
 
 .top-bar,


### PR DESCRIPTION
Link to Jira: https://ctds-planx.atlassian.net/browse/PXP-5598

Adds a CSS fix for a button on the files page that is not the normal BDCat red.