### PR TITLE
feat: update ETL versions

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -6,7 +6,8 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2020.03",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "covid19-etl": "quay.io/cdis/covid19-etl:1.0.5",
+    "covid19-etl": "quay.io/cdis/covid19-etl:1.0.7",
+    "nb-etl": "quay.io/cdis/nb-etl:1.0.7",
     "fence": "quay.io/cdis/fence:2020.03",
     "indexd": "quay.io/cdis/indexd:2020.03",
     "peregrine": "quay.io/cdis/peregrine:2020.03",


### PR DESCRIPTION
Update the Chicagoland Pandemic Response Commons to latest COVID-19 ETL jobs.