### PR TITLE
PXP-5765: updated BRAIN dataprep data dict to v2.1.4

### DIFF
--- a/dataprep.braincommons.org/manifest.json
+++ b/dataprep.braincommons.org/manifest.json
@@ -146,7 +146,7 @@
     "environment": "bhcdatastaging",
     "hostname": "dataprep.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.1.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.1.3/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhcdataprep/user.yaml",
     "dispatcher_job_num": "10",

--- a/dataprep.braincommons.org/manifest.json
+++ b/dataprep.braincommons.org/manifest.json
@@ -146,7 +146,7 @@
     "environment": "bhcdatastaging",
     "hostname": "dataprep.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.1.3/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.1.4/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhcdataprep/user.yaml",
     "dispatcher_job_num": "10",


### PR DESCRIPTION
Breaking change: 
- removed "read_group_qc" node.
- removed family_history.maternal_aunts_and_uncles_number property

https://ctds-planx.atlassian.net/browse/PXP-5765