### PR TITLE
COVID19 enable cards + various fixes

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2020.03",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
     "sheepdog": "quay.io/cdis/sheepdog:4.0.0",
-    "portal": "quay.io/cdis/data-portal:covid19-1.8.1",
+    "portal": "quay.io/cdis/data-portal:covid19-2.0.0",
     "tube": "quay.io/cdis/tube:2020.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.03",

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -35,18 +35,18 @@
       },
       "buttons": [
         {
-          "name": "Define Data Field",
-          "icon": "data-field-define",
-          "body": "The Chicagoland COVID-19 Commons defines the data in a general way. Please study the dictionary before you start browsing.",
-          "link": "/DD",
-          "label": "Learn more"
+          "name": "Browse Jupyter Notebooks",
+          "icon": "data-access",
+          "body": "The notebooks pull data from various external sources to generate and output useful tables, charts, graphs, and models.",
+          "link": "/resource-browser",
+          "label": "Browse notebooks"
         },
         {
-          "name": "Access Data",
-          "icon": "data-access",
-          "body": "An interactive interface provides the ability to query all nodes and properties in the data model.",
-          "link": "/query",
-          "label": "Query data"
+          "name": "Explore Data",
+          "icon": "data-explore",
+          "body": "The Exploration Page gives you insights and a clear overview under selected factors.",
+          "link": "/explorer",
+          "label": "Explore data"
         },
         {
           "name": "Analyze Data",
@@ -54,6 +54,13 @@
           "body": "The Workspace provides a secure cloud environment and features Jupyter Notebooks and RStudio",
           "link": "#hostname#workspace/",
           "label": "Run analysis"
+        },
+        {
+          "name": "Define Data Field",
+          "icon": "data-field-define",
+          "body": "The Chicagoland COVID-19 Commons defines the data in a general way. Study the dictionary before you start browsing.",
+          "link": "/DD",
+          "label": "Learn more"
         }
       ],
       "homepageChartNodes": [

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -52,7 +52,7 @@
           "name": "Analyze Data",
           "icon": "data-analyze",
           "body": "The Workspace provides a secure cloud environment and features Jupyter Notebooks and RStudio",
-          "link": "#hostname#workspace/",
+          "link": "/workspace",
           "label": "Run analysis"
         },
         {

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -74,10 +74,10 @@
     "navigation": {
       "items": [
         {
-          "icon": "dictionary",
-          "link": "/DD",
-          "color": "#a2a2a2",
-          "name": "Dictionary"
+          "name": "Notebook Browser",
+          "link": "/resource-browser",
+          "icon": "query",
+          "color": "#a2a2a2"
         },
         {
           "icon": "exploration",
@@ -86,16 +86,16 @@
           "name": "Exploration"
         },
         {
-          "name": "Notebook Browser",
-          "link": "/resource-browser",
-          "icon": "query",
-          "color": "#a2a2a2"
-        },
-        {
           "icon": "workspace",
           "link": "#hostname#workspace/",
           "color": "#a2a2a2",
           "name": "Workspace"
+        },
+        {
+          "icon": "dictionary",
+          "link": "/DD",
+          "color": "#a2a2a2",
+          "name": "Dictionary"
         },
         {
           "icon": "profile",
@@ -223,6 +223,7 @@
       }
     ]
   },
+  "enableCovid19Dashboard": true,
   "showArboristAuthzOnProfile": true,
   "showFenceAuthzOnProfile": false
 }


### PR DESCRIPTION
covid19-2.0.0 data-portal breaking change: requires `"enableCovid19Dashboard": true` in the config