### PR TITLE
COVID19 remove useless CSS overrides

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.css
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.css
@@ -72,14 +72,6 @@
   border-bottom: 3px solid var(--primary-color);
 }
 
-.nav-bar__logo {
-  padding: 10px 0;
-}
-
-.nav-bar__logo-img {
-  height: 64px;
-}
-
 .footer__version-area {
   width: 300px;
 }


### PR DESCRIPTION
these overrides have the same values as the default, and are preventing us from displaying improved CSS