### PR TITLE
chore(qa): Add all SDETs as codeowners just as FYI for gen3 monthly releases

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,21 @@
-acct.bionimbus.org/manifest.json @trevars
-caninedc.org/manifest.json @trevars
-data.bloodpac.org/manifest.json @trevars
-tbi.datacommons.io/manifest.json @trevars
+acct.bionimbus.org/manifest.json @trevars @uc-cdis/planx-qa
+caninedc.org/manifest.json @trevars @uc-cdis/planx-qa
+data.bloodpac.org/manifest.json @trevars @uc-cdis/planx-qa
+tbi.datacommons.io/manifest.json @trevars @uc-cdis/planx-qa
 
-data.braincommons.org/manifest.json @dgrantkeane @m0nhawk
-dataprep.braincommons.org/manifest.json @dgrantkeane @m0nhawk
-staging.braincommons.org/manifest.json @dgrantkeane @m0nhawk
-gen3testing.braincommons.org/manifest.json @dgrantkeane @m0nhawk
+data.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
+dataprep.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
+staging.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
+gen3testing.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
 
-gen3.theanvil.io/manifest.json @GARUPP-zz @Avantol13
-staging.theanvil.io/manifest.json @GARUPP-zz @Avantol13
-internalstaging.theanvil.io/manifest.json @GARUPP-zz @Avantol13
+gen3.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
+staging.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
+internalstaging.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
 
-ibdgc.datacommons.io/manifest.json @gkuffel @paulineribeyre
-jcoin.datacommons.io/manifest.json @gkuffel @paulineribeyre
+ibdgc.datacommons.io/manifest.json @gkuffel @paulineribeyre @uc-cdis/planx-qa
+jcoin.datacommons.io/manifest.json @gkuffel @paulineribeyre @uc-cdis/planx-qa
 
-nci-crdc-staging.datacommons.io/manifest.json @ADParedes @jiaqi216
-nci-crdc.datacommons.io/manifest.json @ADParedes @jiaqi216
+nci-crdc-staging.datacommons.io/manifest.json @ADParedes @jiaqi216 @uc-cdis/planx-qa
+nci-crdc.datacommons.io/manifest.json @ADParedes @jiaqi216 @uc-cdis/planx-qa
 
-gen3.datacommons.io/manifest.json @cgmeyer
+gen3.datacommons.io/manifest.json @cgmeyer @uc-cdis/planx-qa


### PR DESCRIPTION
Just for general awareness.