### PR TITLE
Fix/validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ script:
     for dir in *; do
       man=$dir/manifest.json; etl=$dir/etlMapping.yaml
       if [ -f $man ] && [ -f $etl ]; then
-        echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+        echo "ETL mapping validation for $dir"
+        gen3utils validate-etl-mapping $etl $man || exit 1
       fi
     done
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ script:
   - |
     for dir in *; do
       man=$dir/manifest.json; etl=$dir/etlMapping.yaml
-      [ -f $man ] && [ -f $etl ] && echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+      if [ -f $man ] && [ -f $etl ]; then
+        echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+      fi
     done
 
   # comment on PRs with relevant deployment changes:


### PR DESCRIPTION
Change how .travis.yml runs ETL mapping validation:

- Use if-statement instead of && to check for manifest and ETL mapping; else if last item in loop happens to not have e.g. an etlmapping, then loop exits with 1 even if all mappings that are present passed validation
- But do exit 1 on validation fail