### PR TITLE
COVID19 portal to v3.2.2 (new homepage data flow)

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2020.05",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
     "sheepdog": "quay.io/cdis/sheepdog:4.1.0",
-    "portal": "quay.io/cdis/data-portal:covid19-3.2.1",
+    "portal": "quay.io/cdis/data-portal:covid19-3.2.2",
     "tube": "quay.io/cdis/tube:0.3.28",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.05",

--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2020.05",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
     "sheepdog": "quay.io/cdis/sheepdog:4.1.0",
-    "portal": "quay.io/cdis/data-portal:covid19-3.1.2",
+    "portal": "quay.io/cdis/data-portal:covid19-3.2.1",
     "tube": "quay.io/cdis/tube:0.3.28",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.05",

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -134,8 +134,7 @@
           {
             "title": "Details",
             "fields": [
-              "program_name",
-              "code",
+              "name",
               "data_description"
             ]
           }
@@ -158,8 +157,8 @@
         "dataType": "dataset",
         "nodeCountTitle": "Datasets",
         "fieldMapping": [
-          { "field": "code", "name": "Dataset" },
-          { "field": "url", "name": "Source" }
+          { "field": "url", "name": "Source" },
+          { "field": "name", "name": "Dataset" }
         ],
         "manifestMapping": {
           "referenceIdFieldInResourceIndex": "code"
@@ -169,17 +168,21 @@
     {
       "tabTitle": "Subjects",
       "charts": {
-        "project_code": {
-          "chartType": "count",
-          "title": "Datasets"
+        "project_name": {
+          "chartType": "bar",
+          "title": "Dataset"
+        },
+        "gender": {
+          "chartType": "pie",
+          "title": "Gender"
+        },
+        "country": {
+          "chartType": "bar",
+          "title": "Country"
         },
         "symptoms": {
           "chartType": "bar",
           "title": "Symptoms"
-        },
-        "source": {
-          "chartType": "pie",
-          "title": "Source"
         }
       },
       "filters": {
@@ -187,7 +190,7 @@
           {
             "title": "Clinical",
             "fields": [
-              "project_code",
+              "project_name",
               "symptoms",
               "death",
               "recovered",
@@ -203,6 +206,7 @@
               "country",
               "province",
               "city",
+              "gender",
               "age",
               "from_wuhan",
               "visiting_wuhan"
@@ -232,8 +236,8 @@
         "nodeCountTitle": "Subjects",
         "fieldMapping" : [
           { "field": "project_url", "name": "Dataset Source" },
-          { "field": "project_code", "name": "Dataset" },
-          { "field": "project_name", "name": "Dataset Name" }
+          { "field": "project_code", "name": "Dataset Code" },
+          { "field": "project_name", "name": "Dataset" }
         ],
         "manifestMapping": {
           "referenceIdFieldInResourceIndex": "subject_id"
@@ -257,7 +261,7 @@
           {
             "title": "Viral",
             "fields": [
-              "project_code",
+              "project_name",
               "data_type",
               "data_format"
             ]
@@ -302,8 +306,8 @@
         "dataType": "file",
         "fieldMapping": [
           { "field": "project_url", "name": "Dataset Source" },
-          { "field": "project_code", "name": "Dataset" },
-          { "field": "project_name", "name": "Dataset Name" },
+          { "field": "project_code", "name": "Dataset Code" },
+          { "field": "project_name", "name": "Dataset" },
           { "field": "object_id", "name": "GUID" }
         ],
         "nodeCountTitle": "Files",


### PR DESCRIPTION
- new homepage data flow
- remove program.name from faceted search
- rename project.code: "dataset" -> "dataset code"
- rename project.name: "dataset name" -> "dataset"
- subjects tab: remove "source" chart, add "gender" filter and chart, add "dataset" and "country" charts
- small updates to match prod config