### PR TITLE
chore(qa): Deploy pelican-export 2020.05 to intern. staging theanvil

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -49,7 +49,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2020.04",
+        "image": "quay.io/cdis/pelican-export:2020.05",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
Correcting pelican-export version.