### PR TITLE
chore(qa): Remove unnecessary ambassador service

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -23,8 +23,7 @@
     "sower": "quay.io/cdis/sower:2020.06",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "jupyterhub": "quay.io/occ_data/jupyterhub:2020.05",
-    "metadata": "quay.io/cdis/metadata-service:2020.06",
-    "ambassador": "quay.io/datawire/ambassador:1.4.2"
+    "metadata": "quay.io/cdis/metadata-service:2020.06"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
remove ambassador from the manifest - it's only used in combination with hatchery