### PR TITLE
removing non PMs from the CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@ data.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
 dataprep.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
 staging.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
 gen3testing.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
-tbi.datacommons.io/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
+tbi.datacommons.io/manifest.json @dgrantkeane @uc-cdis/planx-qa
 
 gen3.theanvil.io/manifest.json @GARUPP-zz @uc-cdis/planx-qa
 staging.theanvil.io/manifest.json @GARUPP-zz @uc-cdis/planx-qa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,28 +1,28 @@
-acct.bionimbus.org/manifest.json @ac3eb
-caninedc.org/manifest.json @trevars
-data.bloodpac.org/manifest.json @fantix
-genomel.bionimbus.org/manifest.json @trevars
+acct.bionimbus.org/manifest.json @ac3eb @uc-cdis/planx-qa
+caninedc.org/manifest.json @trevars @uc-cdis/planx-qa
+data.bloodpac.org/manifest.json @fantix @uc-cdis/planx-qa
+genomel.bionimbus.org/manifest.json @trevars @uc-cdis/planx-qa
 
-data.braincommons.org/manifest.json @dgrantkeane
-dataprep.braincommons.org/manifest.json @dgrantkeane
-staging.braincommons.org/manifest.json @dgrantkeane
-gen3testing.braincommons.org/manifest.json @dgrantkeane
-tbi.datacommons.io/manifest.json @dgrantkeane @m0nhawk
+data.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
+dataprep.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
+staging.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
+gen3testing.braincommons.org/manifest.json @dgrantkeane @uc-cdis/planx-qa
+tbi.datacommons.io/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
 
-gen3.theanvil.io/manifest.json @GARUPP-zz
-staging.theanvil.io/manifest.json @GARUPP-zz
-internalstaging.theanvil.io/manifest.json @GARUPP-zz
+gen3.theanvil.io/manifest.json @GARUPP-zz @uc-cdis/planx-qa
+staging.theanvil.io/manifest.json @GARUPP-zz @uc-cdis/planx-qa
+internalstaging.theanvil.io/manifest.json @GARUPP-zz @uc-cdis/planx-qa
 
-gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
-preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
-staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
+gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @uc-cdis/planx-qa
+preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @uc-cdis/planx-qa
+staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @uc-cdis/planx-qa
 
-ibdgc.datacommons.io/manifest.json @gkuffel
-jcoin.datacommons.io/manifest.json @gkuffel
+ibdgc.datacommons.io/manifest.json @gkuffel @uc-cdis/planx-qa
+jcoin.datacommons.io/manifest.json @gkuffel @uc-cdis/planx-qa
 
-nci-crdc-staging.datacommons.io/manifest.json @ADParedes
-nci-crdc.datacommons.io/manifest.json @ADParedes
+nci-crdc-staging.datacommons.io/manifest.json @ADParedes @uc-cdis/planx-qa
+nci-crdc.datacommons.io/manifest.json @ADParedes @uc-cdis/planx-qa
 
-gen3.datacommons.io/manifest.json @cgmeyer
+gen3.datacommons.io/manifest.json @cgmeyer @uc-cdis/planx-qa
 
-portal.occ-data.org/manifest.json @leasalvatore
+portal.occ-data.org/manifest.json @leasalvatore @uc-cdis/planx-qa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,28 +1,28 @@
-acct.bionimbus.org/manifest.json @ac3eb @fantix @uc-cdis/planx-qa
-caninedc.org/manifest.json @trevars @fantix @uc-cdis/planx-qa
-data.bloodpac.org/manifest.json @fantix @uc-cdis/planx-qa
-genomel.bionimbus.org/manifest.json @trevars @fantix @uc-cdis/planx-qa
+acct.bionimbus.org/manifest.json @ac3eb
+caninedc.org/manifest.json @trevars
+data.bloodpac.org/manifest.json @fantix
+genomel.bionimbus.org/manifest.json @trevars
 
-data.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
-dataprep.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
-staging.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
-gen3testing.braincommons.org/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
-tbi.datacommons.io/manifest.json @dgrantkeane @m0nhawk @uc-cdis/planx-qa
+data.braincommons.org/manifest.json @dgrantkeane
+dataprep.braincommons.org/manifest.json @dgrantkeane
+staging.braincommons.org/manifest.json @dgrantkeane
+gen3testing.braincommons.org/manifest.json @dgrantkeane
+tbi.datacommons.io/manifest.json @dgrantkeane @m0nhawk
 
-gen3.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
-staging.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
-internalstaging.theanvil.io/manifest.json @GARUPP-zz @Avantol13 @uc-cdis/planx-qa
+gen3.theanvil.io/manifest.json @GARUPP-zz
+staging.theanvil.io/manifest.json @GARUPP-zz
+internalstaging.theanvil.io/manifest.json @GARUPP-zz
 
-gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @Avantol13 @uc-cdis/planx-qa
-preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @Avantol13 @uc-cdis/planx-qa
-staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb @Avantol13 @uc-cdis/planx-qa
+gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
+preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
+staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json @ac3eb
 
-ibdgc.datacommons.io/manifest.json @gkuffel @paulineribeyre @uc-cdis/planx-qa
-jcoin.datacommons.io/manifest.json @gkuffel @paulineribeyre @uc-cdis/planx-qa
+ibdgc.datacommons.io/manifest.json @gkuffel
+jcoin.datacommons.io/manifest.json @gkuffel
 
-nci-crdc-staging.datacommons.io/manifest.json @ADParedes @jiaqi216 @uc-cdis/planx-qa
-nci-crdc.datacommons.io/manifest.json @ADParedes @jiaqi216 @uc-cdis/planx-qa
+nci-crdc-staging.datacommons.io/manifest.json @ADParedes
+nci-crdc.datacommons.io/manifest.json @ADParedes
 
-gen3.datacommons.io/manifest.json @cgmeyer @uc-cdis/planx-qa
+gen3.datacommons.io/manifest.json @cgmeyer
 
-portal.occ-data.org/manifest.json @leasalvatore @fantix @uc-cdis/planx-qa
+portal.occ-data.org/manifest.json @leasalvatore


### PR DESCRIPTION
there is no control on the number of reviews for automerge

So it is possible for PMs not be aware of the automerge operation if someone else accidentally approves the PR. Hence keeping only PMs on the list for now

