### PR TITLE
feat: bdcat file count

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
@@ -124,6 +124,9 @@ mappings:
           - name: data_type
             src: data_type
             fn: set
+          - name: file_count
+            src: file_id
+            fn: count
   - name: internalstaging_file
     doc_type: file
     type: collector

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -320,6 +320,7 @@
     "guppyConfig": {
       "dataType": "subject",
       "nodeCountTitle": "Subjects",
+      "fileCountField": "file_count",
       "fieldMapping": [
         { "field": "consent_codes", "name": "Data Use Restriction" },
         { "field": "cac_score", "name": "CAC Score" },


### PR DESCRIPTION
Matches identical PR to qa-dcp that has been previously merged: https://github.com/uc-cdis/gitops-qa/commit/bf2f5814596188f05ec0602f78fe405ba1f88119

This PR provides a new field on the subject node called file_count. The presence of this field in the guppy config will enable a block of code in data-portal written by Qingya that optimizes certain queries in the Data Explorer.

This code change fulfills https://ctds-planx.atlassian.net/browse/PXP-5424

After pulling these code changes, please run the ETL again and reroll Guppy.