### PR TITLE
chore(remove-old-dcfbuckets): removed a transferred bucket from fence…

### DIFF
--- a/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml
+++ b/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml
@@ -29,8 +29,6 @@ S3_BUCKETS:
     cred: 'fence_bot'
   gdc-nciccr-phs001444-controlled:
     cred: 'fence_bot'
-  gdc-organoid-pancreatic-phs001611-controlled:
-    cred: 'fence_bot'
   gdc-organoid-pancreatic-phs001611-2-controlled:
     cred: 'fence_bot'
   gdc-varepop-apollo-phs001374-controlled:


### PR DESCRIPTION
Removed transferred bucket from dcf fence-config so it can be deleted without causing service interruption to fence.

