### PR TITLE
chore(qa): Homogenize bdcat preprod and prod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -27,7 +27,8 @@
     "wts": "quay.io/cdis/workspace-token-service:2020.06",
     "manifestservice": "quay.io/cdis/manifestservice:2020.06",
     "data-ingestion-pipeline": "quay.io/cdis/bdcat-data-ingestion:1.1",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.06"
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.06",
+    "dashboard": "quay.io/cdis/gen3-statics:1.0.0"
   },
   "google": {
     "enabled": "yes"

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -367,7 +367,7 @@
       "accessibleValidationField": "project_id"
     },
     "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
-    "terraExportURL": "https://datastage.terra.bio/#import-data",
+    "terraExportURL": "https://terra.biodatacatalyst.nhlbi.nih.gov/#import-data",
     "terraTemplate": [ 
       "bdc",
       "gen3"


### PR DESCRIPTION
Bringing changes from prod into preprod to avoid discrepancies that may cause misleading test results.