### PR TITLE
Update manifest.json  for new release of fence with support for GA4GH visa 

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.19.0",
+    "fence": "quay.io/cdis/fence:4.20.0",
     "arborist": "quay.io/cdis/arborist:2020.07",
     "google-sa-validation": "placeholder:2020.07",
     "indexd": "quay.io/cdis/indexd:2020.07",


### PR DESCRIPTION
added new release of fence with support for GA4GH Visas in userinfo and has tested and validated that it works on qa-dcf