### PR TITLE
Update RAS to show the most recent visa

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.20.0",
+    "fence": "quay.io/cdis/fence:4.20.1",
     "arborist": "quay.io/cdis/arborist:2020.07",
     "google-sa-validation": "placeholder:2020.07",
     "indexd": "quay.io/cdis/indexd:2020.07",


### PR DESCRIPTION
- update fence on nci-crdc-staging. RAS now shows only the recent visas instead of appending them. 