### PR TITLE
chore(anvil): lower hatchery resources

### DIFF
--- a/gen3.theanvil.io/manifests/hatchery/hatchery.json
+++ b/gen3.theanvil.io/manifests/hatchery/hatchery.json
@@ -3,7 +3,7 @@
   "sub-dir": "/lw-workspace",
   "user-volume-size": "500Gi",
   "sidecar": {
-    "cpu-limit": "1.0",
+    "cpu-limit": "0.5",
     "memory-limit": "512Mi",
     "image": "quay.io/cdis/gen3fuse-sidecar:2020.07",
     "env": {
@@ -68,8 +68,8 @@
     },
     {
       "target-port": 8888,
-      "cpu-limit": "4.0",
-      "memory-limit": "15512Mi",
+      "cpu-limit": "1.0",
+      "memory-limit": "6000Mi",
       "name": "Jupyter Notebook Power Python",
       "image": "quay.io/occ_data/jupyternotebook:1.7.2",
       "env": {},


### PR DESCRIPTION
some pods won't schedule - I think because sidecar is asking for too much cpu - there's also one app with excessive resource requests for the nodes deployed in this environment