### PR TITLE
Feat: Add scopes to ras access_token and userinfo in crdc staging

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.22.1",
+    "fence": "quay.io/cdis/fence:4.22.2",
     "arborist": "quay.io/cdis/arborist:2020.07",
     "google-sa-validation": "placeholder:2020.07",
     "indexd": "quay.io/cdis/indexd:2020.07",


### PR DESCRIPTION
- Add new 'scopes' claim to access tokens (for GA4GH AAI); add
ga4gh_passport_v1 to user/session scopes 
- Make (for now only one of the) claims returned in userinfo responsive to
scopes present in access token 