### PR TITLE
Fix: Ras scope rollback on crdc-staging

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.22.2",
+    "fence": "quay.io/cdis/fence:4.22.1",
     "arborist": "quay.io/cdis/arborist:2020.07",
     "google-sa-validation": "placeholder:2020.07",
     "indexd": "quay.io/cdis/indexd:2020.07",


### PR DESCRIPTION
- rolling back since SB was unable to get visas using access_token