### PR TITLE
chore(qa): Bump up fence version for pre-release RAS testing

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -9,7 +9,7 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2020.08",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.08",
+    "fence": "quay.io/cdis/fence:4.22.4",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "guppy": "quay.io/cdis/guppy:2020.08",
     "hatchery": "quay.io/cdis/hatchery:2020.08",


### PR DESCRIPTION
Deploying `fence:4.22.4` to TheAnvil internalstaging.