### PR TITLE
dcf staging limit service account and handle consent deny

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.22.4",
+    "fence": "quay.io/cdis/fence:4.23.0",
     "arborist": "quay.io/cdis/arborist:2020.08",
     "google-sa-validation": "placeholder:2020.08",
     "indexd": "quay.io/cdis/indexd:2020.08",


### PR DESCRIPTION
- Handle consent deny from any idp 
- Limit project per service account to 6