### PR TITLE
Deploy export to Seven Bridges to BDC preprod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -291,6 +291,12 @@
         "rightIcon": "external-link"
       },
       {
+        "enabled": true, 
+        "type": "export-to-seven-bridges",
+        "title": "Export All to Seven Bridges", 
+        "rightIcon": "external-link"
+      },
+      {
         "enabled": true,
         "type": "export-to-pfb",
         "title": "Export to PFB",
@@ -371,7 +377,8 @@
     "terraTemplate": [ 
       "bdc",
       "gen3"
-    ]
+    ],
+    "sevenBridgesExportURL": "https://platform.sb.biodatacatalyst.nhlbi.nih.gov/import/windmill"
   },
   "fileExplorerConfig": {
     "charts": {


### PR DESCRIPTION
Adds the `Export to Seven Bridges` button to the Data tab in BDCat preprod. Using Seven Bridges PFB handoff URL `https://platform.sb.biodatacatalyst.nhlbi.nih.gov/import/windmill`