### PR TITLE
chore(qa): Deploy gen3fuse-sidecar 2020.08 to theanvil internal staging

### DIFF
--- a/internalstaging.theanvil.io/manifests/hatchery/hatchery.json
+++ b/internalstaging.theanvil.io/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "512Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2020.07",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2020.08",
     "env": {
       "NAMESPACE": "internalanvil",
       "HOSTNAME": "internalstaging.theanvil.io"


### PR DESCRIPTION
TheAnvil internal staging is still running `gen3fuse-sidecar:2020.07`.
The whole environment must be on `2020.08` prior to the release to PROD.