### PR TITLE
chore(qa): upgrade fence to 4.23.2 in dcf staging

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "fence": "quay.io/cdis/fence:4.23.0",
+    "fence": "quay.io/cdis/fence:4.23.2",
     "arborist": "quay.io/cdis/arborist:2020.08",
     "google-sa-validation": "placeholder:2020.08",
     "indexd": "quay.io/cdis/indexd:2020.08",


### PR DESCRIPTION
Keeping fence in sync with other environments that participated in the 2020.08 release cycle.