### PR TITLE
Deploy tube 0.4.1 to BDCat preprod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -19,7 +19,7 @@
     "portal": "quay.io/cdis/data-portal:2.33.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "tube": "quay.io/cdis/tube:2020.08",
+    "tube": "quay.io/cdis/tube:0.4.1",
     "guppy": "quay.io/cdis/guppy:2020.08",
     "sower": "quay.io/cdis/sower:2020.08",
     "hatchery": "quay.io/cdis/hatchery:2020.08",


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/PXP-6544

### Environments
- https://preprod.gen3.biodatacatalyst.nhlbi.nih.gov/

### Description of changes
- Deploy tube `0.4.1` which has the `source_node` feature. Resolves an issue with previous PR https://github.com/uc-cdis/cdis-manifest/pull/2053
