### PR TITLE
fix(qa): Remove duplicate bucket entry from fence public config

### DIFF
--- a/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml
+++ b/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml
@@ -49,8 +49,6 @@ S3_BUCKETS:
     cred: 'fence_bot'
   gdc-target-phs000218-2-open:
     cred: 'fence_bot'
-  gdc-nciccr-phs001444-2-open:
-    cred: 'fence_bot'
   gdc-beataml1-cohort-phs001657-2-open:
     cred: 'fence_bot'
   gdc-beataml1.0-crenolanib-phs001628-2-open:


### PR DESCRIPTION
Small fix to unblock release automation.

Blocked due to duplicate entry:
https://github.com/uc-cdis/cdis-manifest/blob/c6a66f5b33c183417de58febbfc3ea1db4ab1925/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml#L74
https://github.com/uc-cdis/cdis-manifest/blob/c6a66f5b33c183417de58febbfc3ea1db4ab1925/nci-crdc.datacommons.io/manifests/fence/fence-config-public.yaml#L52