### PR TITLE
(BDCat Preprod) Update pelican-export jobs and gitops.json to work w/ tube 0.4.1

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -50,7 +50,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2020.09",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.0",
         "pull_policy": "Always",
         "env": [
           {
@@ -114,7 +114,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:0.5.0",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.0",
         "pull_policy": "Always",
         "env": [
           {

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -189,7 +189,7 @@
         "chartType": "count",
         "title": "Projects"
       },
-      "subject_id": {
+      "_subject_id": {
         "chartType": "count",
         "title": "Subjects"
       },
@@ -213,7 +213,7 @@
             "studies_submitter_id",
             "geographic_site",
             "data_type",
-            "data_format"            
+            "data_format"
           ]
         },
         {
@@ -266,7 +266,7 @@
             "pmv_entvol_bld",
             "rbc_ncnc_bld",
             "rdw_ratio_rbc",
-            "wbc_ncnc_bld"    
+            "wbc_ncnc_bld"
           ]
         }
       ]
@@ -324,10 +324,10 @@
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
-        "referenceIdFieldInDataIndex": "subject_id"
+        "referenceIdFieldInResourceIndex": "_subject_id",
+        "referenceIdFieldInDataIndex": "_subject_id"
       },
-      "nodeCountField": "subject_id"
+      "nodeCountField": "_subject_id"
     },
     "guppyConfig": {
       "dataType": "subject",
@@ -373,8 +373,8 @@
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
-        "referenceIdFieldInDataIndex": "subject_id"
+        "referenceIdFieldInResourceIndex": "_subject_id",
+        "referenceIdFieldInDataIndex": "_subject_id"
       },
       "accessibleFieldCheckList": ["project_id"],
       "accessibleValidationField": "project_id"
@@ -430,7 +430,7 @@
       "nodeCountTitle": "Files",
       "manifestMapping": {
         "resourceIndexType": "subject",
-        "resourceIdField": "subject_id",
+        "resourceIdField": "_subject_id",
         "referenceIdFieldInResourceIndex": "object_id",
         "referenceIdFieldInDataIndex": "object_id"
       },


### PR DESCRIPTION
### Environments
- https://preprod.gen3.biodatacatalyst.nhlbi.nih.gov/

### Description of changes
- Adds fixes to gitops.json (replacing `subject_id` -> `_subject_id`) to work with `tube: 0.4.1`, which prepends an underscore to the `{subject,case}_id` and `file_id` fields.
- Updates all pelican-export jobs to `0.5.0`, which works with `tube: 0.4.1`