### PR TITLE
BDCat preprod pelican bugfix

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -50,7 +50,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.0",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.1",
         "pull_policy": "Always",
         "env": [
           {
@@ -114,7 +114,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.0",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.1",
         "pull_policy": "Always",
         "env": [
           {

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -113,6 +113,19 @@
         }
       ]
     },
+    "topBar": {
+      "items": [
+        {
+          "icon": "upload",
+          "link": "/submission",
+          "name": "Submit Data"
+        },
+        {
+          "link": "https://bdcatalyst.gitbook.io/biodata-catalyst-documentation/explore_data/gen3-discovering-data",
+          "name": "Documentation"
+        }
+      ]
+    },
     "login": {
       "title": "NHLBI BioData Catalyst",
       "subTitle": "Explore, Analyze, and Share Data",


### PR DESCRIPTION


### Environments
- https://preprod.gen3.biodatacatalyst.nhlbi.nih.gov/

### Description of changes
- Update pelican-export job version to [0.5.1](https://github.com/uc-cdis/pelican/releases/tag/0.5.1), which fixes a bug in exporting PFBs from the files tab
- Update the URL of the Documentation button in the top bar