### PR TITLE
`subject_id` -> `_subject_id` in anvil internalstaging

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -23,7 +23,7 @@
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2020.09",
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2020.09",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2020.09",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.4.1",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.4.2",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2020.09",
     "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2020.09",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2020.09",
@@ -57,7 +57,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.0",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.5.1",
         "pull_policy": "Always",
         "env": [
           {

--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -148,12 +148,12 @@
             "sex",
             "age_value",
             "ancestry",
-            "disease_description", 
-            "phenotype_present", 
-            "phenotype_absent", 
-            "disease_id", 
-            "solve_state", 
-            "congenital_status", 
+            "disease_description",
+            "phenotype_present",
+            "phenotype_absent",
+            "disease_id",
+            "solve_state",
+            "congenital_status",
             "age_of_onset",
             "phenotype_group"
           ]
@@ -169,12 +169,12 @@
         }, {
           "title": "Sequencing",
           "fields": [
-            "library_prep_kit_method", 
-            "exome_capture_platform", 
-            "capture_region_bed_file", 
-            "reference_genome_build", 
-            "sequencing_assay", 
-            "alignment_method", 
+            "library_prep_kit_method",
+            "exome_capture_platform",
+            "capture_region_bed_file",
+            "reference_genome_build",
+            "sequencing_assay",
+            "alignment_method",
             "data_processing_pipeline"
           ]
         }
@@ -243,17 +243,17 @@
       "dataType": "subject",
       "nodeCountTitle": "Subjects",
       "fieldMapping": [
-        { "field": "disease_id", "name": "Disease ID" }, 
+        { "field": "disease_id", "name": "Disease ID" },
         { "field": "age_of_onset", "name": "Age of Onset" },
         { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
         { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
-        { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}    
+        { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}
       ],
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
-        "referenceIdFieldInDataIndex": "subject_id"
+        "referenceIdFieldInResourceIndex": "_subject_id",
+        "referenceIdFieldInDataIndex": "_subject_id"
       },
       "accessibleFieldCheckList": ["project_id"],
       "accessibleValidationField": "project_id"
@@ -281,7 +281,7 @@
             "data_category",
             "data_type",
             "data_format",
-            "analyte_type", 
+            "analyte_type",
             "sequencing_assay"
           ]
         }
@@ -310,7 +310,7 @@
       "nodeCountTitle": "Files",
       "manifestMapping": {
         "resourceIndexType": "subject",
-        "resourceIdField": "subject_id",
+        "resourceIdField": "_subject_id",
         "referenceIdFieldInResourceIndex": "object_id",
         "referenceIdFieldInDataIndex": "object_id"
       },


### PR DESCRIPTION
### Environments
- https://internalstaging.theanvil.io/

### Description of changes
- Rename `subject_id` -> `_subject_id` in portal config. Tube 0.4.1 (deployed) has a breaking change requiring subject_id
to be renamed to _subject_id.
- Bump tube version from `0.4.1` -> `0.4.2` for consistency with BDCat
- Bump pelican-export version from `0.5.0` -> `0.5.1` for consistency with BDCat