### PR TITLE
fix: include ui-component button class in color overrides

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.css
@@ -1,6 +1,7 @@
 :root {
   --primary-color: #c02f42;
   --secondary-color: #6d6e70;
+  --g3-primary-btn__bg-color: #c02f42;
 }
 
 /* Buttons */


### PR DESCRIPTION
This PR makes the default button color point to the primary color of bdcat. An identical PR has already been merged to qa-dcp. 