### PR TITLE
Update BRAIN Commons dictionary to v3.0.

### DIFF
--- a/dataprep.braincommons.org/manifest.json
+++ b/dataprep.braincommons.org/manifest.json
@@ -236,7 +236,7 @@
     "environment": "bhcdatastaging",
     "hostname": "dataprep.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.5.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/3.0/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhcdataprep/user.yaml",
     "dispatcher_job_num": "10",


### PR DESCRIPTION
This PR is for the v3.0 release for BC. Below is a summary of the updates being made:

1. New properties for several wearable data sets including CIS-PD, REAL-PD, and RAWProMini
2. A couple of typos are being fixed -
-- concentration_impairment_scoare is being removed (no data have been submitted for this property) and concentration_impairment_score is being added.
-- 4 properties in the use_of_force_survey.yaml had the wrong enums and those have been changed to Yes/No
-- A new definition was added for the physical_activity_scale node
-- A few new refs were added for terms that were already in the _terms.yaml
3. Note that I committed several changes because there were some issues with the tsv<>yaml tool that I needed to fix, I kept finding typos, and we decided to add an additional assessment after the initial commit.
