### PR TITLE
chore/update etl and manifest for VacTracker

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/etlMapping.yaml
+++ b/chicagoland.pandemicresponsecommons.org/etlMapping.yaml
@@ -154,6 +154,26 @@ mappings:
     parent_props:
       - path: projects[project_code:code,project_name:name,project_url:url,project_data_description:data_description,project_investigator_affiliation:investigator_affiliation,project_availability_type:availability_type]
       - path: studies[study_doi:study_doi]
+  - name: covid19_clinical_trials
+    doc_type: clinical_trials
+    type: aggregator
+    root: clinical_trials
+    props:
+      - name: project_id
+      - name: completed_clinical_trials
+      - name: description
+      - name: development_stage
+      - name: fda_regulated_drug_product
+      - name: focus
+      - name: inprogress_clinical_trials
+      - name: location
+      - name: nct_number
+      - name: phase
+      - name: sponsor
+      - name: technology
+      - name: title
+    parent_props:
+      - path: projects[project_code:code,project_name:name,project_url:url,project_data_description:data_description,project_investigator_affiliation:investigator_affiliation,project_availability_type:availability_type]
   - name: covid19_genomic_file
     doc_type: genomic_file
     type: collector

--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -14,8 +14,8 @@
     "pidgin": "quay.io/cdis/pidgin:2020.08",
     "revproxy": "quay.io/cdis/nginx:2020.08",
     "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "tube": "quay.io/cdis/tube:0.4.0",
     "portal": "quay.io/cdis/data-portal:covid19-3.8.1",
+    "tube": "quay.io/cdis/tube:0.4.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.08",
     "hatchery": "quay.io/cdis/hatchery:2020.08",
@@ -215,6 +215,10 @@
       {
         "index": "covid19_subject",
         "type": "subject"
+      },
+      {
+        "index": "covid19_clinical_trials",
+        "type": "clinical_trials"
       },
       {
         "index": "covid19_dataset",


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://occ-data.atlassian.net/browse/COV-452
### Environments
prod-covid19

### Description of changes
Update the ETL mapping and manifest to support portal changes for the VacTracker dataset.