### PR TITLE
Update BRAIN Commons dictionary to v3.1

### DIFF
--- a/dataprep.braincommons.org/manifest.json
+++ b/dataprep.braincommons.org/manifest.json
@@ -236,7 +236,7 @@
     "environment": "bhcdatastaging",
     "hostname": "dataprep.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/3.0/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/3.1/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhcdataprep/user.yaml",
     "dispatcher_job_num": "10",


### PR DESCRIPTION
Updating the BRAIN Commons dictionary with some minor updates after v3.0. Update details can be found here: https://docs.google.com/spreadsheets/d/1ZLjIyxBV14En0Ajncy1BbTBLuSxbF3lQwMuqg-ILnGc/edit#gid=1912840596