### PR TITLE
BDC Preprod / Anvil internalstaging _subject_id ETL fix

### DIFF
--- a/internalstaging.theanvil.io/etlMapping.yaml
+++ b/internalstaging.theanvil.io/etlMapping.yaml
@@ -76,7 +76,7 @@ mappings:
         fn: count
     joining_props:
       - index: file
-        join_on: subject_id
+        join_on: _subject_id
         props:
           - name: data_format
             src: data_format
@@ -109,15 +109,15 @@ mappings:
       - name: state
       - name: data_category
       - name: analyte_type
-      - name: sequencing_assay      
+      - name: sequencing_assay
     injecting_props:
       subject:
         props:
-          - name: subject_id
+          - name: _subject_id
             src: id
             fn: set
           - name: subject_submitter_id
             src: submitter_id
-            fn: set            
+            fn: set
           - name: project_id
             fn: set

--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -252,7 +252,7 @@
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
+        "referenceIdFieldInResourceIndex": "_subject_id",
         "referenceIdFieldInDataIndex": "_subject_id"
       },
       "accessibleFieldCheckList": ["project_id"],

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
@@ -118,7 +118,7 @@ mappings:
       - path: studies[studies_submitter_id:submitter_id]
     joining_props:
       - index: file
-        join_on: subject_id
+        join_on: _subject_id
         props:
           - name: data_format
             src: data_format
@@ -148,6 +148,6 @@ mappings:
     injecting_props:
       subject:
         props:
-          - name: subject_id
+          - name: _subject_id
             src: id
           - name: project_id


### PR DESCRIPTION

### Environments
- preprod.gen3.biodatacatalyst.nhlbi.nih.gov
- internalstaging.theanvil.io

### Description of changes
- Replace all remaining instances of `subject_id` -> `_subject_id` to resolve `joining_props`-related etl issues in BDC and Anvil preprod. (Slack thread: https://cdis.slack.com/archives/CN0E43KQC/p1602095148308200?thread_ts=1602093431.304700&cid=CN0E43KQC)

