### PR TITLE
Fix/datacommons tube underscore fix

### DIFF
--- a/gen3.datacommons.io/etlMapping.yaml
+++ b/gen3.datacommons.io/etlMapping.yaml
@@ -44,7 +44,7 @@ mappings:
         fn: count
     joining_props:
       - index: file
-        join_on: subject_id
+        join_on: _subject_id
         props:
           - name: data_format
             src: data_format
@@ -72,6 +72,6 @@ mappings:
     injecting_props:
       subject:
         props:
-          - name: subject_id
+          - name: _subject_id
             src: id
           - name: project_id

--- a/gen3.datacommons.io/portal/gitops.json
+++ b/gen3.datacommons.io/portal/gitops.json
@@ -214,8 +214,8 @@
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
-        "referenceIdFieldInDataIndex": "subject_id"
+        "referenceIdFieldInResourceIndex": "_subject_id",
+        "referenceIdFieldInDataIndex": "_subject_id"
       },
       "accessibleFieldCheckList": ["project_id"],
       "accessibleValidationField": "project_id"
@@ -280,7 +280,7 @@
       "nodeCountTitle": "Files",
       "manifestMapping": {
         "resourceIndexType": "subject",
-        "resourceIdField": "subject_id",
+        "resourceIdField": "_subject_id",
         "referenceIdFieldInResourceIndex": "object_id",
         "referenceIdFieldInDataIndex": "object_id"
       },


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- gen3.datacommons.io

### Description of changes
- Fix for tube 2020.10 underscore issue -- `subject_id` -> `_subject_id` in etlMapping and gitops.json