### PR TITLE
Fix: Anvil Prod ETL issue 

### DIFF
--- a/gen3.theanvil.io/etlMapping.yaml
+++ b/gen3.theanvil.io/etlMapping.yaml
@@ -76,7 +76,7 @@ mappings:
         fn: count
     joining_props:
       - index: file
-        join_on: subject_id
+        join_on: _subject_id
         props:
           - name: data_format
             src: data_format
@@ -113,7 +113,7 @@ mappings:
     injecting_props:
       subject:
         props:
-          - name: subject_id
+          - name: _subject_id
             src: id
             fn: set
           - name: subject_submitter_id

--- a/gen3.theanvil.io/portal/gitops.json
+++ b/gen3.theanvil.io/portal/gitops.json
@@ -104,8 +104,21 @@
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"
     },
-    "categorical9Colors": ["#035C94", "#7EBAC0", "#AEEBF2", "#E0DD10", "#40476D", "#FFA630", "#AE8799", "#035C94", "#462255"],
-    "categorical2Colors": ["#035C94", "#7EBAC0"]
+    "categorical9Colors": [
+      "#035C94",
+      "#7EBAC0",
+      "#AEEBF2",
+      "#E0DD10",
+      "#40476D",
+      "#FFA630",
+      "#AE8799",
+      "#035C94",
+      "#462255"
+    ],
+    "categorical2Colors": [
+      "#035C94",
+      "#7EBAC0"
+    ]
   },
   "featureFlags": {
     "explorer": true
@@ -131,7 +144,7 @@
     },
     "filters": {
       "tabs": [
-         {
+        {
           "title": "Projects",
           "fields": [
             "project_id",
@@ -141,9 +154,10 @@
             "project_dbgap_phs",
             "project_name"
           ]
-         }, {
+        },
+        {
           "title": "Subject",
-          "fields":[
+          "fields": [
             "anvil_project_id",
             "sex",
             "age_value",
@@ -157,7 +171,8 @@
             "age_of_onset",
             "phenotype_group"
           ]
-        }, {
+        },
+        {
           "title": "Sample",
           "fields": [
             "sample_provider",
@@ -166,7 +181,8 @@
             "sample_type",
             "original_material_type"
           ]
-        }, {
+        },
+        {
           "title": "Sequencing",
           "fields": [
             "library_prep_kit_method",
@@ -243,19 +259,36 @@
       "dataType": "subject",
       "nodeCountTitle": "Subjects",
       "fieldMapping": [
-        { "field": "disease_id", "name": "Disease ID" },
-        { "field": "age_of_onset", "name": "Age of Onset" },
-        { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
-        { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
-        { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}
+        {
+          "field": "disease_id",
+          "name": "Disease ID"
+        },
+        {
+          "field": "age_of_onset",
+          "name": "Age of Onset"
+        },
+        {
+          "field": "project_dbgap_accession_number",
+          "name": "Project dbGaP Accession Number"
+        },
+        {
+          "field": "project_dbgap_consent_text",
+          "name": "Project dbGaP Consent Text"
+        },
+        {
+          "field": "project_dbgap_phs",
+          "name": "Project dbGaP Phs"
+        }
       ],
       "manifestMapping": {
         "resourceIndexType": "file",
         "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "subject_id",
+        "referenceIdFieldInResourceIndex": "_subject_id",
         "referenceIdFieldInDataIndex": "_subject_id"
       },
-      "accessibleFieldCheckList": ["project_id"],
+      "accessibleFieldCheckList": [
+        "project_id"
+      ],
       "accessibleValidationField": "project_id"
     },
     "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
@@ -305,7 +338,10 @@
     "guppyConfig": {
       "dataType": "file",
       "fieldMapping": [
-        { "field": "object_id", "name": "GUID" }
+        {
+          "field": "object_id",
+          "name": "GUID"
+        }
       ],
       "nodeCountTitle": "Files",
       "manifestMapping": {
@@ -314,7 +350,9 @@
         "referenceIdFieldInResourceIndex": "object_id",
         "referenceIdFieldInDataIndex": "object_id"
       },
-      "accessibleFieldCheckList": ["project_id"],
+      "accessibleFieldCheckList": [
+        "project_id"
+      ],
       "accessibleValidationField": "project_id",
       "downloadAccessor": "object_id"
     },


### PR DESCRIPTION
Contains changes to etlMapping.yaml and gitops.json changes cherry-picked from this automated PR (we didn't want to include the other changes from the automated PR) https://github.com/uc-cdis/cdis-manifest/pull/2173

### Environments
- gen3.theanvil.io

### Description of changes
- subject_id -> _subject_id in anvil prod gitops.json and etlMapping. Resolves a ETL issue causing the Download Manifest button to not work in the Data tab (https://cdis.slack.com/archives/CN0E43KQC/p1602093431304700)