### PR TITLE
Increment dd version to 3.4.5 and etl version to 4.2.2

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -32,7 +32,7 @@
     "environment": "covid19-prod",
     "hostname": "chicagoland.pandemicresponsecommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:236714345101:certificate/e5edf56f-4003-4ee3-9ecd-162aaf19c058",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.3.5/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.4.5/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-covid19-prod-gen3",
     "logs_bucket": "s3logs-logs-covid19-prod-gen3",

--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -6,7 +6,7 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2020.08",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "covid19-etl": "quay.io/cdis/covid19-etl:4.2.1",
+    "covid19-etl": "quay.io/cdis/covid19-etl:4.2.2",
     "nb-etl": "quay.io/cdis/covid19-nb-etl:4.0.2",
     "fence": "quay.io/cdis/fence:2020.08",
     "indexd": "quay.io/cdis/indexd:2020.08",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
prod-covid19

### Description of changes
Increment dd version to 3.4.5 to obtain updated prop for VacTracker dataset.