### PR TITLE
feat: add cleversafe tab to anvil internalstaging

### DIFF
--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -110,232 +110,393 @@
   "featureFlags": {
     "explorer": true
   },
-  "dataExplorerConfig": {
-    "charts": {
-      "project_id": {
-        "chartType": "count",
-        "title": "Projects"
-      },
-      "node_id": {
-        "chartType": "count",
-        "title": "Subjects"
-      },
-      "sex": {
-        "chartType": "pie",
-        "title": "Sex"
-      },
-      "ancestry": {
-        "chartType": "bar",
-        "title": "Ancestry"
-      }
-    },
-    "filters": {
-      "tabs": [
-         {
-          "title": "Projects",
-          "fields": [
-            "project_id",
-            "project_short_name",
-            "project_dbgap_accession_number",
-            "project_dbgap_consent_text",
-            "project_dbgap_phs",
-            "project_name"
-          ]
-         }, {
-          "title": "Subject",
-          "fields":[
-            "anvil_project_id",
-            "sex",
-            "age_value",
-            "ancestry",
-            "disease_description",
-            "phenotype_present",
-            "phenotype_absent",
-            "disease_id",
-            "solve_state",
-            "congenital_status",
-            "age_of_onset",
-            "phenotype_group"
-          ]
-        }, {
-          "title": "Sample",
-          "fields": [
-            "sample_provider",
-            "tissue_affected_status",
-            "tissue_type",
-            "sample_type",
-            "original_material_type"
-          ]
-        }, {
-          "title": "Sequencing",
-          "fields": [
-            "library_prep_kit_method",
-            "exome_capture_platform",
-            "capture_region_bed_file",
-            "reference_genome_build",
-            "sequencing_assay",
-            "alignment_method",
-            "data_processing_pipeline"
-          ]
+  "explorerConfig": [
+    {
+      "tabTitle": "Data",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "node_id": {
+          "chartType": "count",
+          "title": "Subjects"
+        },
+        "sex": {
+          "chartType": "pie",
+          "title": "Sex"
+        },
+        "ancestry": {
+          "chartType": "bar",
+          "title": "Ancestry"
         }
-      ]
-    },
-    "table": {
-      "enabled": true,
-      "fields": [
-        "project_id",
-        "anvil_project_id",
-        "ancestry",
-        "sex",
-        "age_value",
-        "phenotype_group",
-        "_samples_count",
-        "_sequencings_count"
-      ]
-    },
-    "dropdowns": {
-      "download": {
-        "title": "Download"
-      }
-    },
-    "buttons": [
-      {
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Projects",
+            "fields": [
+              "project_id",
+              "project_short_name",
+              "project_dbgap_accession_number",
+              "project_dbgap_consent_text",
+              "project_dbgap_phs",
+              "project_name"
+            ]
+          }, {
+            "title": "Subject",
+            "fields":[
+              "anvil_project_id",
+              "sex",
+              "age_value",
+              "ancestry",
+              "disease_description",
+              "phenotype_present",
+              "phenotype_absent",
+              "disease_id",
+              "solve_state",
+              "congenital_status",
+              "age_of_onset",
+              "phenotype_group"
+            ]
+          }, {
+            "title": "Sample",
+            "fields": [
+              "sample_provider",
+              "tissue_affected_status",
+              "tissue_type",
+              "sample_type",
+              "original_material_type"
+            ]
+          }, {
+            "title": "Sequencing",
+            "fields": [
+              "library_prep_kit_method",
+              "exome_capture_platform",
+              "capture_region_bed_file",
+              "reference_genome_build",
+              "sequencing_assay",
+              "alignment_method",
+              "data_processing_pipeline"
+            ]
+          }
+        ]
+      },
+      "table": {
         "enabled": true,
-        "type": "data",
-        "title": "Download Clinical",
-        "leftIcon": "user",
-        "rightIcon": "download",
-        "fileName": "clinical.json",
-        "dropdownId": "download",
-        "tooltipText": "You have not selected any subjects to download. Please use the checkboxes on the left to select specific subjects you would like to download."
+        "fields": [
+          "project_id",
+          "anvil_project_id",
+          "ancestry",
+          "sex",
+          "age_value",
+          "phenotype_group",
+          "_samples_count",
+          "_sequencings_count"
+        ]
       },
-      {
-        "enabled": true,
-        "type": "manifest",
-        "title": "Download Manifest",
-        "leftIcon": "datafile",
-        "rightIcon": "download",
-        "fileName": "manifest.json",
-        "dropdownId": "download"
+      "dropdowns": {
+        "download": {
+          "title": "Download"
+        }
       },
-      {
-        "enabled": true,
-        "type": "export",
-        "title": "Export All to Terra",
-        "rightIcon": "external-link"
-      },
-      {
-        "enabled": true,
-        "type": "export-to-pfb",
-        "title": "Export to PFB",
-        "leftIcon": "datafile",
-        "rightIcon": "download"
-      },
-      {
-        "enabled": true,
-        "type": "export-to-workspace",
-        "title": "Export to Workspace",
-        "leftIcon": "datafile",
-        "rightIcon": "download"
-      }
-    ],
-    "guppyConfig": {
-      "dataType": "subject",
-      "nodeCountTitle": "Subjects",
-      "fieldMapping": [
-        { "field": "disease_id", "name": "Disease ID" },
-        { "field": "age_of_onset", "name": "Age of Onset" },
-        { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
-        { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
-        { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}
-      ],
-      "manifestMapping": {
-        "resourceIndexType": "file",
-        "resourceIdField": "object_id",
-        "referenceIdFieldInResourceIndex": "_subject_id",
-        "referenceIdFieldInDataIndex": "_subject_id"
-      },
-      "accessibleFieldCheckList": ["project_id"],
-      "accessibleValidationField": "project_id"
-    },
-    "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
-    "terraExportURL": "https://anvil.terra.bio/#import-data"
-  },
-  "fileExplorerConfig": {
-    "charts": {
-      "data_type": {
-        "chartType": "stackedBar",
-        "title": "File Type"
-      },
-      "data_format": {
-        "chartType": "stackedBar",
-        "title": "File Format"
-      }
-    },
-    "filters": {
-      "tabs": [
+      "buttons": [
         {
-          "title": "File",
-          "fields": [
-            "project_id",
-            "data_category",
-            "data_type",
-            "data_format",
-            "analyte_type",
-            "sequencing_assay"
-          ]
+          "enabled": true,
+          "type": "data",
+          "title": "Download Clinical",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "clinical.json",
+          "dropdownId": "download",
+          "tooltipText": "You have not selected any subjects to download. Please use the checkboxes on the left to select specific subjects you would like to download."
+        },
+        {
+          "enabled": true,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json",
+          "dropdownId": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-pfb",
+          "title": "Export to PFB",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
         }
-      ]
-    },
-    "table": {
-      "enabled": true,
-      "fields": [
-        "project_id",
-        "subject_submitter_id",
-        "file_name",
-        "data_format",
-        "data_type",
-        "data_category",
-        "file_size",
-        "submitter_id",
-        "object_id",
-        "md5sum"
-      ]
-    },
-    "guppyConfig": {
-      "dataType": "file",
-      "fieldMapping": [
-        { "field": "object_id", "name": "GUID" }
       ],
-      "nodeCountTitle": "Files",
-      "manifestMapping": {
-        "resourceIndexType": "subject",
-        "resourceIdField": "_subject_id",
-        "referenceIdFieldInResourceIndex": "object_id",
-        "referenceIdFieldInDataIndex": "object_id"
+      "guppyConfig": {
+        "dataType": "subject",
+        "nodeCountTitle": "Subjects",
+        "fieldMapping": [
+          { "field": "disease_id", "name": "Disease ID" },
+          { "field": "age_of_onset", "name": "Age of Onset" },
+          { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
+          { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
+          { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}
+        ],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "_subject_id",
+          "referenceIdFieldInDataIndex": "_subject_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
       },
-      "accessibleFieldCheckList": ["project_id"],
-      "accessibleValidationField": "project_id",
-      "downloadAccessor": "object_id"
+      "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
+      "terraExportURL": "https://anvil.terra.bio/#import-data"
     },
-    "buttons": [
-      {
-        "enabled": true,
-        "type": "file-manifest",
-        "title": "Download Manifest",
-        "leftIcon": "datafile",
-        "rightIcon": "download",
-        "fileName": "file-manifest.json",
-        "dropdownId": "download"
+    {
+      "tabTitle": "File",
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
+        }
       },
-      {
+      "filters": {
+        "tabs": [
+          {
+            "title": "File",
+            "fields": [
+              "project_id",
+              "data_category",
+              "data_type",
+              "data_format",
+              "analyte_type",
+              "sequencing_assay"
+            ]
+          }
+        ]
+      },
+      "table": {
         "enabled": true,
-        "type": "export-files-to-workspace",
-        "title": "Export to Workspace",
-        "leftIcon": "datafile",
-        "rightIcon": "download"
-      }
-    ],
-    "dropdowns": {}
-  }
+        "fields": [
+          "project_id",
+          "subject_submitter_id",
+          "file_name",
+          "data_format",
+          "data_type",
+          "data_category",
+          "file_size",
+          "submitter_id",
+          "object_id",
+          "md5sum"
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "file-manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "file-manifest.json",
+          "dropdownId": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "dropdowns": {}
+    },
+    {
+      "tabTitle": "Downloadable",
+      "adminAppliedPreFilters": {
+        "project_id": { 
+          "selectedValues": ["CMG-Broad-GRU"]
+        }
+      },
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "node_id": {
+          "chartType": "count",
+          "title": "Subjects"
+        },
+        "sex": {
+          "chartType": "pie",
+          "title": "Sex"
+        },
+        "ancestry": {
+          "chartType": "bar",
+          "title": "Ancestry"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Projects",
+            "fields": [
+              "project_id",
+              "project_short_name",
+              "project_dbgap_accession_number",
+              "project_dbgap_consent_text",
+              "project_dbgap_phs",
+              "project_name"
+            ]
+          }, {
+            "title": "Subject",
+            "fields":[
+              "anvil_project_id",
+              "sex",
+              "age_value",
+              "ancestry",
+              "disease_description",
+              "phenotype_present",
+              "phenotype_absent",
+              "disease_id",
+              "solve_state",
+              "congenital_status",
+              "age_of_onset",
+              "phenotype_group"
+            ]
+          }, {
+            "title": "Sample",
+            "fields": [
+              "sample_provider",
+              "tissue_affected_status",
+              "tissue_type",
+              "sample_type",
+              "original_material_type"
+            ]
+          }, {
+            "title": "Sequencing",
+            "fields": [
+              "library_prep_kit_method",
+              "exome_capture_platform",
+              "capture_region_bed_file",
+              "reference_genome_build",
+              "sequencing_assay",
+              "alignment_method",
+              "data_processing_pipeline"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "anvil_project_id",
+          "ancestry",
+          "sex",
+          "age_value",
+          "phenotype_group",
+          "_samples_count",
+          "_sequencings_count"
+        ]
+      },
+      "dropdowns": {
+        "download": {
+          "title": "Download"
+        }
+      },
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "data",
+          "title": "Download Clinical",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "clinical.json",
+          "dropdownId": "download",
+          "tooltipText": "You have not selected any subjects to download. Please use the checkboxes on the left to select specific subjects you would like to download."
+        },
+        {
+          "enabled": true,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json",
+          "dropdownId": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-pfb",
+          "title": "Export to PFB",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "subject",
+        "nodeCountTitle": "Subjects",
+        "fieldMapping": [
+          { "field": "disease_id", "name": "Disease ID" },
+          { "field": "age_of_onset", "name": "Age of Onset" },
+          { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
+          { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
+          { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}
+        ],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "_subject_id",
+          "referenceIdFieldInDataIndex": "_subject_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      },
+      "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
+      "terraExportURL": "https://anvil.terra.bio/#import-data"
+    }
+  ]
 }


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/PXP-6744

Preview of how these changes look using dev.html:
![Screen Shot 2020-10-12 at 2 07 10 PM](https://user-images.githubusercontent.com/7152954/95782116-ced9b780-0c94-11eb-9c48-e52bca619326.png)


These changes have already been merged to qa-anvil in this identical PR: https://github.com/uc-cdis/gitops-qa/commit/c20de4c395f63374d806047fb2f4d6f0451cdd72

### Environments
- Anvil Internal Staging


### Description of changes
- Adds a new tab to Anvil Internal Staging titled "Downloadable" with an admin pre-applied filter displaying mock data symbolizing the Cleversafe GTEx v8 project.