### PR TITLE
feat: change internal staging anvil downloadable tab to point to CF-GTEx

### DIFF
--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -345,7 +345,7 @@
       "tabTitle": "Downloadable",
       "adminAppliedPreFilters": {
         "project_id": { 
-          "selectedValues": ["CMG-Broad-GRU"]
+          "selectedValues": ["CF-GTEx"]
         }
       },
       "charts": {


### PR DESCRIPTION
A preview of this change:
![Screen Shot 2020-10-15 at 11 01 34 AM](https://user-images.githubusercontent.com/7152954/96155719-df2ca500-0ed5-11eb-8b23-192a09e244f5.png)


### Environments
- Anvil Internal Staging

### Description of changes
- Alter "Downloadable" tab to point to CF-GTEx study.