### PR TITLE
updated cards to remove Open Access references

### DIFF
--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -37,28 +37,28 @@
             {
               "name": "Data Dictionary",
               "icon": "data-field-define",
-              "body": "Browse the nodes and properties of the graph data model used in the Open Access Data Commons.",
+              "body": "Browse the nodes and properties of the graph data model used in the MIDRC Data Commons.",
               "link": "/DD",
               "label": "Explore Data Model"
             },
             {
               "name": "Explore Data",
               "icon": "data-explore",
-              "body": "Search and download subsets of data from the Open Access Data Commons using intuitive navigation tools.",
+              "body": "Search and download subsets of data from the MIDRC Data Commons using intuitive navigation tools.",
               "link": "/explorer",
               "label": "Explore data"
             },
             {
               "name": "Query Data",
               "icon": "data-access",
-              "body": "Search and download subsets of data from the Open Access Data Commons using GraphQL queries.",
+              "body": "Search and download subsets of data from the MIDRC Data Commons using GraphQL queries.",
               "link": "/query",
               "label": "Query data"
             },
             {
               "name": "Analyze Data",
               "icon": "data-analyze",
-              "body": "Perform analysis on the Open Access Data Commons data using Jupyter Notebooks.",
+              "body": "Perform analysis on the MIDRC Data Commons data using Jupyter Notebooks.",
               "link": "/workspace",
               "label": "Run analysis"
             }


### PR DESCRIPTION
Update references from “Open Access Data Commons” to “MIDRC Data Commons” on landing page cards