### PR TITLE
Fix for BDCat preprod etlMapping

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
@@ -152,4 +152,3 @@ mappings:
             src: id
             fn: set
           - name: project_id
-            fn: set


### PR DESCRIPTION

### Environments
- preprod.gen3.biodatacatalyst.nhlbi.nih.gov/

### Description of changes
- Remove unnecessary`fn: set` for `file.project_id`. Resolves a bug causing File tab table to not show `project_id` field.