### PR TITLE
Updating staging.braincommons.org to v3.1

### DIFF
--- a/staging.braincommons.org/manifest.json
+++ b/staging.braincommons.org/manifest.json
@@ -236,7 +236,7 @@
     "environment": "bhcstaging",
     "hostname": "staging.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.5.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/3.1/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhcstaging/user.yaml",
     "dispatcher_job_num": "10",


### PR DESCRIPTION
Updating staging.braincommons.org to v3.1. To see updates for 3.1 see the following document:

https://docs.google.com/spreadsheets/d/1ZLjIyxBV14En0Ajncy1BbTBLuSxbF3lQwMuqg-ILnGc/edit#gid=1912840596