### PR TITLE
Updating production (data.braincommons.org) with v3.1 release

### DIFF
--- a/data.braincommons.org/manifest.json
+++ b/data.braincommons.org/manifest.json
@@ -236,7 +236,7 @@
     "environment": "bhcprodv2",
     "hostname": "data.braincommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:728066667777:certificate/3dfa6ec9-320b-4ce6-ab83-967e286a4d76",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/2.5.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bhcdictionary/3.1/schema.json",
     "portal_app": "gitops",
     "useryaml_s3path": "s3://cdis-gen3-users/bhc/user.yaml",
     "dispatcher_job_num": "5",


### PR DESCRIPTION
We need to update production with the 3.1 release- a description of the changes can be found at the link below:

https://docs.google.com/spreadsheets/d/1lxHiM_ky5onipRXCSZgk1eug8Gy4Zi3UgHnEZ7m_3HU/edit#gid=1704931732