### PR TITLE
feat(vpodc): refine the filters on Files tab in Explorer

### DIFF
--- a/vpodc.org/portal/gitops.json
+++ b/vpodc.org/portal/gitops.json
@@ -260,7 +260,7 @@
               "project_id",
               "data_type",
               "data_format",
-              "file_id",
+              "_file_id",
               "file_name",
               "file_size",
               "object_id"
@@ -284,7 +284,7 @@
           "submitter_id",
           "data_type",
           "data_format",
-          "file_id",
+          "_file_id",
           "file_name",
           "file_size",
           "object_id"

--- a/vpodc.org/portal/gitops.json
+++ b/vpodc.org/portal/gitops.json
@@ -260,10 +260,7 @@
               "project_id",
               "data_type",
               "data_format",
-              "_file_id",
-              "file_name",
-              "file_size",
-              "object_id"
+              "file_size"
             ]
           }
         ]
@@ -284,7 +281,6 @@
           "submitter_id",
           "data_type",
           "data_format",
-          "_file_id",
           "file_name",
           "file_size",
           "object_id"


### PR DESCRIPTION
### Environments
* vpodc.org

### Description of changes
* Refine the Filters on Files tab in Explorer: it doesn't make sense to include the filter for filename, file_id and object_id (as they are all unique and it would be slow to load)