### PR TITLE
fix: missing DAP tag injection control

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/portal/gitops.json
+++ b/accessclinicaldata.niaid.nih.gov/portal/gitops.json
@@ -1,5 +1,6 @@
 {
   "gaTrackingId": "UA-119127212-15",
+  "injectDAPTag": true,
   "graphql": {
     "boardCounts": [],
     "chartCounts": [],


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
NCT

### Description of changes
add missing config field for injecting DAT tag script into header