### PR TITLE
NCT portal to 2.38.0

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -16,7 +16,7 @@
     "pidgin": "quay.io/cdis/pidgin:2020.11",
     "revproxy": "quay.io/cdis/nginx:2020.11",
     "sheepdog": "quay.io/cdis/sheepdog:2020.11",
-    "portal": "quay.io/cdis/data-portal:2.37.0",
+    "portal": "quay.io/cdis/data-portal:2.38.0",
     "tube": "quay.io/cdis/tube:2020.11",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.11",

--- a/accessclinicaldata.niaid.nih.gov/portal/gitops.json
+++ b/accessclinicaldata.niaid.nih.gov/portal/gitops.json
@@ -72,7 +72,6 @@
   "explorerConfig": [],
   "studyViewerConfig": [
     {
-      "openMode": "close-all",
       "dataType": "clinical_trials",
       "title": "Studies",
       "titleField": "title",
@@ -113,6 +112,8 @@
       ],
       "fileDataType": "ctfile",
       "docDataType": "oafile",
+      "openMode": "close-all",
+      "defaultOrderBy": ["title", "asc"],
       "buttons": [
         {
           "type": "download"


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/PXP-7063

### Environments
NCT

### Description of changes
portal to 2.38.0 (this fix https://github.com/uc-cdis/data-portal/pull/757 and this feature https://github.com/uc-cdis/data-portal/pull/758), order study viewer cards by title