### PR TITLE
fix(bdcat-proprod): hatchery namespace

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/hatchery/hatchery.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/hatchery/hatchery.json
@@ -1,5 +1,5 @@
 {
-  "user-namespace": "jupyter-pods-internalstaging",
+  "user-namespace": "jupyter-pods-bdcat-internalstaging",
   "sub-dir": "/lw-workspace",
   "user-volume-size": "500Gi",
   "sidecar": {


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments

preprod.gen3.bdcat

### Description of changes

hatchery namespace is not following expected naming convention - breaks reaper