### PR TITLE
chore(dictionary): update to dictionary version 3.7.2

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -32,7 +32,7 @@
     "environment": "covid19-prod",
     "hostname": "chicagoland.pandemicresponsecommons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:236714345101:certificate/e5edf56f-4003-4ee3-9ecd-162aaf19c058",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.7.1/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.7.2/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-covid19-prod-gen3",
     "logs_bucket": "s3logs-logs-covid19-prod-gen3",


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://occ-data.atlassian.net/browse/COV-534
### Environments
PRC

### Description of changes
Update to dictionary version 3.7.2 which deletes props from the summary clinical node to complete the data migration for the CCMap and OWID2 projects.