### PR TITLE
chore(dcf-staging): patch fence to accept userid

### DIFF
--- a/nci-crdc-staging.datacommons.io/manifest.json
+++ b/nci-crdc-staging.datacommons.io/manifest.json
@@ -14,7 +14,7 @@
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2020.11",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2020.11",
     "datareplicate": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/dcf-dataservice:2020.11",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.23.7",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.24.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "google-sa-validation": "placeholder:2020.11",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2.14.1",


### PR DESCRIPTION
Currently, we look for `UserID` for `username` from RAS's userinfo payload. This is specified in the RAS's Userinfo Paylod. However, they are sending us `UserID` for eraCommons users and `userid` for NIH users.

### Description of changes
- Support `userid` in RAS 
