### PR TITLE
Chore(dcf-prod): datareplicate aws validation and indexd version

### DIFF
--- a/nci-crdc.datacommons.io/manifest.json
+++ b/nci-crdc.datacommons.io/manifest.json
@@ -13,7 +13,7 @@
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.23.7",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "google-sa-validation": "placeholder:2020.11",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2020.11",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2.14.1",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2020.11",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2020.11",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2020.11",

--- a/nci-crdc.datacommons.io/manifest.json
+++ b/nci-crdc.datacommons.io/manifest.json
@@ -9,7 +9,7 @@
   "versions": {
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2020.11",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2020.11",
-    "datareplicate": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/dcf-dataservice:1.2.1",
+    "datareplicate": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/dcf-dataservice:1.2.2",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.23.7",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "google-sa-validation": "placeholder:2020.11",


### PR DESCRIPTION
### Description of changes
- Fix aws validation always showing "object not copied to bucket"
- Update to the latest semantic version of indexd to run bundle ingestion