### PR TITLE
file_id -> _file_id in BDC preprod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
@@ -124,7 +124,7 @@ mappings:
             src: data_type
             fn: set
           - name: file_count
-            src: file_id
+            src: _file_id
             fn: count
   - name: internalstaging_file
     doc_type: file

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/etlMapping.yaml
@@ -124,7 +124,7 @@ mappings:
             src: data_type
             fn: set
           - name: file_count
-            src: _file_id
+            src: file_count
             fn: count
   - name: internalstaging_file
     doc_type: file


### PR DESCRIPTION
### Environments
- preprod.gen3.biodatacatalyst.nhlbi.nih.gov

### Description of changes
- change file_id -> _file_id in etlMapping (due to tube breaking change https://github.com/uc-cdis/tube/releases/tag/0.4.0)