### PR TITLE
deploying 2020.12 to NCT PROD

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -7,25 +7,26 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.11",
+    "arborist": "quay.io/cdis/arborist:2020.12",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.11",
-    "fence": "quay.io/cdis/fence:2020.11",
-    "indexd": "quay.io/cdis/indexd:2.14.0",
-    "peregrine": "quay.io/cdis/peregrine:2020.11",
-    "pidgin": "quay.io/cdis/pidgin:2020.11",
-    "revproxy": "quay.io/cdis/nginx:2020.11",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.11",
+    "dashboard": "quay.io/cdis/gen3-statics:2020.12",
+    "fence": "quay.io/cdis/fence:2020.12",
+    "indexd": "quay.io/cdis/indexd:2020.12",
+    "peregrine": "quay.io/cdis/peregrine:2020.12",
+    "pidgin": "quay.io/cdis/pidgin:2020.12",
+    "revproxy": "quay.io/cdis/nginx:2020.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2020.12",
     "portal": "quay.io/cdis/data-portal:2.39.3",
-    "tube": "quay.io/cdis/tube:2020.11",
+    "tube": "quay.io/cdis/tube:2020.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:2020.11",
+    "spark": "quay.io/cdis/gen3-spark:2020.12",
     "requestor": "quay.io/cdis/requestor:1.2.0",
-    "hatchery": "quay.io/cdis/hatchery:2020.11",
-    "wts": "quay.io/cdis/workspace-token-service:2020.11",
+    "hatchery": "quay.io/cdis/hatchery:2020.12",
+    "wts": "quay.io/cdis/workspace-token-service:2020.12",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "quay.io/cdis/guppy:2020.11",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.11"
+    "guppy": "quay.io/cdis/guppy:2020.12",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.12",
+    "metadata": "quay.io/cdis/metadata-service:2020.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -51,7 +52,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.11"
+      "indexing": "quay.io/cdis/indexs3client:2020.12"
     }
   },
   "canary": {

--- a/accessclinicaldata.niaid.nih.gov/manifests/hatchery/hatchery.json
+++ b/accessclinicaldata.niaid.nih.gov/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2020.11",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2020.12",
     "env": {
       "NAMESPACE": "default",
       "HOSTNAME": "accessclinicaldata.niaid.nih.gov"

--- a/accessclinicaldata.niaid.nih.gov/portal/gitops.json
+++ b/accessclinicaldata.niaid.nih.gov/portal/gitops.json
@@ -38,7 +38,7 @@
         },
         {
           "icon": "workspace",
-          "link": "#hostname#workspace/",
+          "link": "/workspace",
           "color": "#a2a2a2",
           "name": "Workspace"
         }


### PR DESCRIPTION
This PR

1. deploying 2020.12 to NCT prod
2. adding `metadata-service` to the service block as with `ssjdispatcher version 2020.12` it is mandatory to deploy `metadata-service`
3. correcting the `/workspace`