### PR TITLE
feat: change Anvil "Downloadable" tab to file type

### DIFF
--- a/internalstaging.theanvil.io/etlMapping.yaml
+++ b/internalstaging.theanvil.io/etlMapping.yaml
@@ -125,3 +125,39 @@ mappings:
             fn: set
           - name: project_id
             fn: set
+          - name: anvil_project_id
+            src: anvil_project_id
+            fn: set
+          - name: sex
+            src: sex
+            fn: set
+          - name: age_value
+            src: age_value
+            fn: set
+          - name: ancestry
+            src: ancestry
+            fn: set
+          - name: disease_description
+            src: disease_description
+            fn: set
+          - name: phenotype_present
+            src: phenotype_present
+            fn: set
+          - name: phenotype_absent
+            src: phenotype_absent
+            fn: set
+          - name: disease_id
+            src: disease_id
+            fn: set
+          - name: solve_state
+            src: solve_state
+            fn: set
+          - name: congenital_status
+            src: congenital_status
+            fn: set
+          - name: age_of_onset
+            src: age_of_onset
+            fn: set
+          - name: phenotype_group
+            src: phenotype_group
+            fn: set

--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -384,40 +384,28 @@
         }
       },
       "charts": {
-        "project_id": {
-          "chartType": "count",
-          "title": "Projects"
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
         },
-        "node_id": {
-          "chartType": "count",
-          "title": "Subjects"
-        },
-        "sex": {
-          "chartType": "pie",
-          "title": "Sex"
-        },
-        "ancestry": {
-          "chartType": "bar",
-          "title": "Ancestry"
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
         }
       },
       "filters": {
         "tabs": [
           {
-            "title": "Projects",
+            "title": "File",
             "fields": [
               "project_id",
-              "project_short_name",
-              "project_dbgap_accession_number",
-              "project_dbgap_consent_text",
-              "project_dbgap_phs",
-              "project_name",
+              "data_category",
               "data_type",
               "data_format",
-              "data_category"
+              "analyte_type",
+              "sequencing_assay"
             ]
-          },
-          {
+          }, {
             "title": "Subject",
             "fields": [
               "anvil_project_id",
@@ -433,28 +421,6 @@
               "age_of_onset",
               "phenotype_group"
             ]
-          },
-          {
-            "title": "Sample",
-            "fields": [
-              "sample_provider",
-              "tissue_affected_status",
-              "tissue_type",
-              "sample_type",
-              "original_material_type"
-            ]
-          },
-          {
-            "title": "Sequencing",
-            "fields": [
-              "library_prep_kit_method",
-              "exome_capture_platform",
-              "capture_region_bed_file",
-              "reference_genome_build",
-              "sequencing_assay",
-              "alignment_method",
-              "data_processing_pipeline"
-            ]
           }
         ]
       },
@@ -462,96 +428,65 @@
         "enabled": true,
         "fields": [
           "project_id",
-          "anvil_project_id",
-          "ancestry",
-          "sex",
-          "age_value",
-          "phenotype_group",
-          "_samples_count",
-          "_sequencings_count"
+          "subject_submitter_id",
+          "file_name",
+          "data_format",
+          "data_type",
+          "data_category",
+          "file_size",
+          "submitter_id",
+          "object_id",
+          "md5sum"
         ]
       },
-      "dropdowns": {
-        "download": {
-          "title": "Download"
-        }
-      },
       "buttons": [
-        {
+      {
           "enabled": true,
-          "type": "data",
-          "title": "Download Clinical",
-          "leftIcon": "user",
-          "rightIcon": "download",
-          "fileName": "clinical.json",
-          "dropdownId": "download",
-          "tooltipText": "You have not selected any subjects to download. Please use the checkboxes on the left to select specific subjects you would like to download."
-        },
-        {
-          "enabled": true,
-          "type": "manifest",
+          "type": "file-manifest",
           "title": "Download Manifest",
           "leftIcon": "datafile",
           "rightIcon": "download",
-          "fileName": "manifest.json",
-          "dropdownId": "download"
+          "fileName": "file-manifest.json"
         },
         {
           "enabled": true,
-          "type": "export",
-          "title": "Export All to Terra",
-          "rightIcon": "external-link"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-pfb",
-          "title": "Export to PFB",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-workspace",
+          "type": "export-files-to-workspace",
           "title": "Export to Workspace",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
+          "leftIcon": "datafile"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-pfb",
+          "title": "Export All to PFB",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
+        },
+        {
+          "enabled": true,
+          "type": "export-files",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
         }
       ],
       "guppyConfig": {
-        "dataType": "subject",
-        "nodeCountTitle": "Subjects",
+        "dataType": "file",
         "fieldMapping": [
-          {
-            "field": "disease_id",
-            "name": "Disease ID"
-          },
-          {
-            "field": "age_of_onset",
-            "name": "Age of Onset"
-          },
-          {
-            "field": "project_dbgap_accession_number",
-            "name": "Project dbGaP Accession Number"
-          },
-          {
-            "field": "project_dbgap_consent_text",
-            "name": "Project dbGaP Consent Text"
-          },
-          {
-            "field": "project_dbgap_phs",
-            "name": "Project dbGaP Phs"
-          }
+          { "field": "object_id", "name": "GUID" }
         ],
+        "nodeCountTitle": "Files",
         "manifestMapping": {
-          "resourceIndexType": "file",
-          "resourceIdField": "object_id",
-          "referenceIdFieldInResourceIndex": "_subject_id",
-          "referenceIdFieldInDataIndex": "_subject_id"
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
         },
-        "accessibleFieldCheckList": [
-          "project_id"
-        ],
-        "accessibleValidationField": "project_id"
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "enableLimitedFilePFBExport": {
+        "sourceNodeField": "source_node"
       },
       "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
       "terraExportURL": "https://anvil.terra.bio/#import-data"

--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -404,6 +404,9 @@
               "data_format",
               "analyte_type",
               "sequencing_assay"
+            ],
+            "searchFields": [
+              "file_name"
             ]
           }, {
             "title": "Subject",
@@ -452,7 +455,8 @@
           "enabled": true,
           "type": "export-files-to-workspace",
           "title": "Export to Workspace",
-          "leftIcon": "datafile"
+          "leftIcon": "datafile",
+          "rightIcon": "download"
         },
         {
           "enabled": true,
@@ -472,7 +476,10 @@
       "guppyConfig": {
         "dataType": "file",
         "fieldMapping": [
-          { "field": "object_id", "name": "GUID" }
+          {
+            "field": "object_id",
+            "name": "GUID"
+          }
         ],
         "nodeCountTitle": "Files",
         "manifestMapping": {
@@ -481,7 +488,9 @@
           "referenceIdFieldInResourceIndex": "object_id",
           "referenceIdFieldInDataIndex": "object_id"
         },
-        "accessibleFieldCheckList": ["project_id"],
+        "accessibleFieldCheckList": [
+          "project_id"
+        ],
         "accessibleValidationField": "project_id",
         "downloadAccessor": "object_id"
       },


### PR DESCRIPTION
Switching Downloadable tab in the Data Explorer to be based on file index. Currently deployed in https://qa-anvil.planx-pla.net/explorer

This PR is for: https://ctds-planx.atlassian.net/browse/PXP-7385

### Environments
- Affects Anvil internal staging.

### Description of changes
- Changes "Downloadable" tab in Data Explorer to be based on the Files tab rather than the Subjects tab.