### PR TITLE
(COV-578): chore/covid19-jupyter-img: update covid19 jupyter image to 1.1.9

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifests/hatchery/jupyter-covid19.yaml
+++ b/chicagoland.pandemicresponsecommons.org/manifests/hatchery/jupyter-covid19.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    webapp:
-      image: "quay.io/cdis/jupyter-covid19:jupyter-covid1.1.8"
+      image: "quay.io/cdis/jupyter-covid19:jupyter-covid1.1.9"
       volumes:
          - ${DATA_VOLUME}:/data
          - ${USER_VOLUME}:/home/jovyan/pd


### PR DESCRIPTION
https://occ-data.atlassian.net/browse/COV-578

### Environments
chicagoland.pandemicresponsecommons.org

### Description of changes
update covid19 jupyter image to 1.1.9 to include welcome page updates