### PR TITLE
chore(manifest): upgrade gen3-fuse

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
+++ b/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
+    "image": "quay.io/cdis/gen3fuse-sidecar:0.2.3",
     "env": {"NAMESPACE":"default", "HOSTNAME": "chicagoland.pandemicresponsecommons.org"},
     "args": [],
     "command": ["/bin/bash", "/sidecarDockerrun.sh"],

--- a/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
+++ b/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2021.01",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
     "env": {"NAMESPACE":"default", "HOSTNAME": "chicagoland.pandemicresponsecommons.org"},
     "args": [],
     "command": ["/bin/bash", "/sidecarDockerrun.sh"],


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
PRC

### Description of changes
Upgrade gen3-fuse to version 2021.0.2.3 to include fix for adding sleep/retry logic to prevent the fuse sidecar from erroring out each time the workspace pod triggers an auto scaling.