### PR TITLE
PRC fix IGV race condition

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifests/hatchery/gen3-igv.yaml
+++ b/chicagoland.pandemicresponsecommons.org/manifests/hatchery/gen3-igv.yaml
@@ -17,3 +17,5 @@ services:
     container_name: nginx
     ports:
       - ${SERVICE_PORT}:80
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]


### PR DESCRIPTION
Link to Jira ticket if there is one:

deployed to QA https://github.com/uc-cdis/gitops-qa/commit/dba760679fe0e564d205ab97277c43633ddd148a

### Environments
PRC

### Description of changes
The IGV workspace returns a 502 because the [nginx-igv](https://github.com/uc-cdis/containers/tree/81b592d1af6ef6acbd0c2c142b4ac53466b3feaa/nginx-igv) container starts without waiting for the [gen3-igv](https://github.com/uc-cdis/gen3-igv/blob/master/Dockerfile) container to expose data. I tried a few things:
- retrying the [`nginx -g 'daemon off;` command](https://github.com/uc-cdis/containers/blob/81b592d1af6ef6acbd0c2c142b4ac53466b3feaa/nginx-igv/Dockerfile#L6) does not work because nginx does not exit in case of error
- pinging the `gen3-igv` container until it's ready before starting nginx - almost works but the `nginx-igv` container still becomes "ready" too early
```
    command: [
      "/bin/bash",
      "-c",
      "while [[ \"$(curl -s -o /dev/null -w ''%{http_code}'' http://127.0.0.1:3000/)\" != \"200\" ]]; do echo 'Waiting for gen3-igv container...'; sleep 5; done; echo 'gen3-igv is ready'; nginx -g 'daemon off;'"
    ]
```
- hatchery config gotcha: the `ready-probe` param is not available when using `more-configs` - the dockstore equivalent is `healthcheck` ([hatchery doc](https://github.com/uc-cdis/hatchery/blob/2021.02/doc/explanation/dockstore.md)). Adding a `healthcheck` that pings nginx at port 80 works ✔️ I think pinging gen3-igv at port 3000 would also work