### PR TITLE
chore(release): Set empty footerLogos to prevent null values applied by code promotion automation

### DIFF
--- a/internalstaging.theanvil.io/portal/gitops.json
+++ b/internalstaging.theanvil.io/portal/gitops.json
@@ -118,7 +118,8 @@
     "categorical2Colors": [
       "#035C94",
       "#7EBAC0"
-    ]
+    ],
+    "footerLogos": []
   },
   "featureFlags": {
     "explorer": true


### PR DESCRIPTION
Setting empty list to avoid null values in subsequent release cycles.