### PR TITLE
Update manifest.json

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -25,7 +25,7 @@
     "guppy": "quay.io/cdis/guppy:0.10.0",
     "manifestservice": "quay.io/cdis/manifestservice:2021.01",
     "dashboard": "quay.io/cdis/gen3-statics:2021.01",
-    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.7",
+    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.8",
     "sower": "quay.io/cdis/sower:2021.01",
     "metadata": "quay.io/cdis/metadata-service:2021.01"
   },


### PR DESCRIPTION
Update auspice release v2.16.gen3.8 which include phylogeny tree for 950 Sars-CoV-2 sequences

Link to Jira ticket if there is one:

### Environments


### Description of changes
