### PR TITLE
chore/update_covid19-portal: update covid19 data-portal image to 2.46.0

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2021.01",
     "revproxy": "quay.io/cdis/nginx:2021.01",
     "sheepdog": "quay.io/cdis/sheepdog:2021.01",
-    "portal": "quay.io/cdis/data-portal:2.44.0",
+    "portal": "quay.io/cdis/data-portal:2.46.0",
     "tube": "quay.io/cdis/tube:2021.01",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.01",


### PR DESCRIPTION
### Environments
PRC

### Description of changes
- Updated session monitor and logout fixing various bugs
- hide slider filters in the exploration page when empty 
- Adds support for index-scoped tiered access