### PR TITLE
Update portal version to get Discovery page bugfix

### DIFF
--- a/gen3.datacommons.io/manifest.json
+++ b/gen3.datacommons.io/manifest.json
@@ -15,7 +15,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.45.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2021.03",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",


### PR DESCRIPTION


### Environments
- gen3.datacommons.io

### Description of changes
- Update to 2021.03 to include portal routing bugfix that affects envs with the Disco page enabled: https://github.com/uc-cdis/data-portal/pull/825