### PR TITLE
chore(reliability): Adopt awshelper from AWS ECR

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -9,6 +9,7 @@
   "versions": {
     "access-backend": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/access-backend:2021.03",
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.03",
+    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.03",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.27.1",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.03",


### PR DESCRIPTION
Due to intermittent outages with quay.io, we need to adopt an AWS ECR version of the `awshelper` image to improve the resiliency of this environment (to be promoted to PROD asap).