### PR TITLE
updating the auto-label

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-      "test-portal-dataguidOrgTest": ["dataguids.org/"]
+      "test-portal-dataguidOrgTest": ["dataguids.org/"],
+      "jenkins-niaid": ["accessclinicaldata.niaid.nih.gov/"]
     }
   }


### PR DESCRIPTION
The commit in auto-label would allow to run `accessclinicaldata.niaid.nih.gov` related PR on `jenkins-niaid` as study-viewer feature is enabled on `jenkins-niaid` only

So with this the studyViewer test would run on every `accessclinicaldata.niaid.nih.gov` PR
