### PR TITLE
feat/newGuppyFilter: update guppy and adjust flags

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -17,7 +17,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.50.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.51.0",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",
@@ -25,7 +25,7 @@
     "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.03",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.03",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.03",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.03",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.03",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.1",
@@ -234,7 +234,6 @@
       }
     ],
     "config_index": "covid19_array-config",
-    "auth_filter_field": "auth_resource_path",
-    "aggs_include_missing_data": false
+    "auth_filter_field": "auth_resource_path"
   }
 }

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -138,7 +138,8 @@
     "explorer": true,
     "analysis": true,
     "explorerPublic": true,
-    "explorerHideEmptyFilterSection": true
+    "explorerHideEmptyFilterSection": true,
+    "explorerFilterValuesToHide": ["no data"]
   },
   "analysisTools": [],
   "explorerConfig": [


### PR DESCRIPTION
### Environments
PRC

### Description of changes
- Update @gen3/guppy dependency to version 0.13.0 (#837)
- set flags to show "no data" and the use new flags to hide "no data" in filters
- add explorerHideDataFilter and pass it through to guppy (#837)
- Data Explorer state can now be loaded and unloaded to and from the page 
    URL. This feature is disabled by default; it can be enabled with the 
    `explorerStoreFilterInURL` featureFlag in the portal config. (#807)
