### PR TITLE
chore(release): Update fence version for Anvil envs

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -10,7 +10,7 @@
     "access-backend": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/access-backend:2021.04",
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.04",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.04",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.28.2",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.04",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2021.04",


### PR DESCRIPTION
Setting `fence:4.28.2` on Anvil envs to be consistent with BDCat.

@emalinowski , requires a DB upgrade.