### PR TITLE
fix(unblock-april-release): Pin 2021.03 for pelican export sower job on Anvil envs

### DIFF
--- a/internalstaging.theanvil.io/manifest.json
+++ b/internalstaging.theanvil.io/manifest.json
@@ -58,7 +58,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2021.04",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2021.03",
         "pull_policy": "Always",
         "env": [
           {
@@ -122,7 +122,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2021.04",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2021.03",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
Our `pelican-export:2021.04` is failing because pyPfb 0.4.2 does not play well with the latest Anvil DD:
```
Loading dictionary: https://s3.amazonaws.com/dictionary-artifacts/anvil/2.3.0/schema.json
Parsing dictionary...
Traceback (most recent call last):
  File "job_export.py", line 83, in <module>
    _from_dict(pfb_file, dictionary_url)
  File "/usr/local/lib/python3.7/site-packages/pfb/importers/gen3dict.py", line 43, in _from_dict
    records, ontology_references, links = _parse_dictionary(d)
  File "/usr/local/lib/python3.7/site-packages/pfb/importers/gen3dict.py", line 163, in _parse_dictionary
    avro_type = _get_avro_type(property_name, property_type, record_name)
  File "/usr/local/lib/python3.7/site-packages/pfb/importers/gen3dict.py", line 231, in _get_avro_type
    return _array_type(property_type)
  File "/usr/local/lib/python3.7/site-packages/pfb/importers/gen3dict.py", line 244, in _array_type
    return {"items": property_type["items"]["type"], "type": property_type["type"]}
KeyError: 'type'
```