### PR TITLE
chore (release-update) : Update prod-covid19 to 2021.04 version

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -4,33 +4,33 @@
     "That's all I have to say"
   ],
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.03",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.04",
     "augur": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-augur:fix_docker2",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:4.7.4",
     "nb-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-nb-etl:4.7.0",
     "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.7.2",
     "covid19-bayes-model": "quay.io/cdis/covid19-bayes-model:3.4.3",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.03",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.03",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.03",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.04",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.04",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.04",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.04",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.04",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.52.0",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.03",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.04",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.04",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:0.1.5",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.03",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.03",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.04",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.04",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.03",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.03",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.04",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.04",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.1",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.03",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.03"
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.04",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.04"
   },
   "global": {
     "environment": "covid19-prod",
@@ -125,7 +125,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2021.03"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2021.04"
     }
   },
   "sower" : [
@@ -135,7 +135,7 @@
       "serviceAccountName": "jobs-chicagoland-pandemicresponsecommons-org",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2021.03",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2021.04",
         "pull_policy": "Always",
         "env": [
           {
@@ -175,7 +175,7 @@
       "serviceAccountName": "jobs-chicagoland-pandemicresponsecommons-org",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2021.03",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2021.04",
         "pull_policy": "Always",
         "env": [
           {

--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -28,7 +28,7 @@
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.04",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.04",
-    "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.1",
+    "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.2",
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.04",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.04"
   },

--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -17,7 +17,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.04",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.04",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.52.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2021.04",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.04",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.04",

--- a/chicagoland.pandemicresponsecommons.org/manifests/fence/fence-config-public.yaml
+++ b/chicagoland.pandemicresponsecommons.org/manifests/fence/fence-config-public.yaml
@@ -214,6 +214,9 @@ MAX_ACCESS_TOKEN_TTL: 3600
 # auth checks against Arborist, and no longer check the token.
 TOKEN_PROJECTS_CUTOFF: 15
 
+# If set to true, will generate an new access token each time when a browser session update happens
+RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION: true
+
 # //////////////////////////////////////////////////////////////////////////////////////
 # SHIBBOLETH
 #   - Support using `shibboleth` in LOGIN_OPTIONS

--- a/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
+++ b/chicagoland.pandemicresponsecommons.org/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3fuse-sidecar:2021.03",
+    "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3fuse-sidecar:2021.04",
     "env": {"NAMESPACE":"default", "HOSTNAME": "chicagoland.pandemicresponsecommons.org"},
     "args": [],
     "command": ["/bin/bash", "/sidecarDockerrun.sh"],


### PR DESCRIPTION
This PR ->

1. deploy release 2021.04 to PROD COVID19
2. add `RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION: true` in fence public config