### PR TITLE
fix for gen3.datacommons MDS/Discover page

### DIFF
--- a/gen3.datacommons.io/manifest.json
+++ b/gen3.datacommons.io/manifest.json
@@ -15,7 +15,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2021.03",
+    "portal": "quay.io/cdis/data-portal:chore_gen3-data-commons-mds-fix",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",

--- a/gen3.datacommons.io/portal/gitops.json
+++ b/gen3.datacommons.io/portal/gitops.json
@@ -66,6 +66,13 @@
           "label": "Query data"
         },
         {
+          "name": "Discover Study Metadata",
+          "icon": "data-explore",
+          "body": "Discover study descriptions and other metadata stored on the Data Commons",
+          "link": "/discovery",
+          "label": "Discover Study Metadata"
+        },
+        {
           "name": "Analyze Data",
           "icon": "data-analyze",
           "body": "Perform analysis on the Open Access Data Commons data using Jupyter Notebooks.",
@@ -76,6 +83,11 @@
     },
     "navigation": {
       "items": [
+        {
+          "icon": "query",
+          "link": "/discovery",
+          "name": "Discovery"
+        },
         {
           "icon": "dictionary",
           "link": "/DD",
@@ -145,7 +157,131 @@
   "requiredCerts": [],
   "featureFlags": {
     "explorer": true,
-    "noIndex": true
+    "noIndex": true,
+    "discovery": true
+  },
+  "discoveryConfig": {
+    "features": {
+      "pageTitle": {
+        "enabled": false
+      },
+      "search": {
+        "searchBar": {
+          "enabled": true
+        }
+      },
+      "authorization": {
+        "enabled": false
+      }
+    },
+    "aggregations": [
+      {
+        "name": "Studies",
+        "field": "accession_number",
+        "type": "count"
+      }
+    ],
+    "tagSelector": {
+      "title": "Tags by category"
+    },
+    "studyColumns": [
+      {
+        "name": "Accession Number",
+        "field": "accession_number"
+      },
+      {
+        "name": "Study Title",
+        "field": "study_title"
+      },
+      {
+        "name": "Funding",
+        "field": "funding"
+      },
+      {
+        "name": "Source",
+        "field": "source"
+      },
+      {
+        "name": "Data Files",
+        "field": "data_files_count"
+      },
+      {
+        "name": "Subjects",
+        "field": "subjects_count"
+      }
+    ],
+    "studyPreviewField": {
+      "name": "Summary",
+      "field": "summary",
+      "contentType": "string",
+      "includeName": false,
+      "includeIfNotAvailable": true,
+      "valueIfNotAvailable": "No summary has been provided for this study."
+    },
+    "studyPageFields": {
+      "header": {
+        "field": "study_title"
+      },
+      "fieldsToShow": [
+        {
+          "groupName": "OADC studies",
+          "includeName": false,
+          "fields": [
+            {
+              "name": "Accession Number",
+              "field": "accession_number"
+            },
+            {
+              "name": "Study Title",
+              "field": "study_title"
+            },
+            {
+              "name": "Funding",
+              "field": "funding"
+            },
+            {
+              "name": "Source",
+              "field": "source"
+            },
+            {
+              "name": "Data Files",
+              "field": "data_files_count"
+            },
+            {
+              "name": "Subjects",
+              "field": "subjects_count"
+            },
+            {
+              "name": "Link",
+              "field": "link"
+            }
+          ]
+        },
+        {
+          "fields": [
+            {
+              "name": "Summary",
+              "field": "summary",
+              "contentType": "paragraphs",
+              "includeName": true,
+              "includeIfNotAvailable": true,
+              "valueIfNotAvailable": "No summary has been provided for this study."
+            }
+          ]
+        }
+      ]
+    },
+    "minimalFieldMapping": {
+      "tagsListFieldName": "tags",
+      "uid": "accession_number"
+    },
+    "tagCategories": [
+      {
+        "name": "Data Type",
+        "color": "rgba(71, 130, 195, 1)",
+        "display": true
+      }
+    ]
   },
   "dataExplorerConfig": {
     "charts": {
@@ -206,11 +342,26 @@
       "dataType": "subject",
       "nodeCountTitle": "Subjects",
       "fieldMapping": [
-        {"field": "_samples_count", "name": "Samples Count"},
-        {"field": "_imaging_files_count", "name": "Imaging Files Count"},
-        {"field": "_unaligned_reads_files_count", "name": "Unaligned Reads Count"},
-        {"field": "_aligned_reads_files_count", "name": "Aligned Reads Count"},
-        {"field": "_expression_arrays_count", "name": "Expression Arrays Count"}
+        {
+          "field": "_samples_count",
+          "name": "Samples Count"
+        },
+        {
+          "field": "_imaging_files_count",
+          "name": "Imaging Files Count"
+        },
+        {
+          "field": "_unaligned_reads_files_count",
+          "name": "Unaligned Reads Count"
+        },
+        {
+          "field": "_aligned_reads_files_count",
+          "name": "Aligned Reads Count"
+        },
+        {
+          "field": "_expression_arrays_count",
+          "name": "Expression Arrays Count"
+        }
       ],
       "manifestMapping": {
         "resourceIndexType": "file",
@@ -218,7 +369,9 @@
         "referenceIdFieldInResourceIndex": "subject_id",
         "referenceIdFieldInDataIndex": "subject_id"
       },
-      "accessibleFieldCheckList": ["project_id"],
+      "accessibleFieldCheckList": [
+        "project_id"
+      ],
       "accessibleValidationField": "project_id"
     },
     "buttons": [
@@ -240,7 +393,7 @@
       }
     ]
   },
-   "fileExplorerConfig": {
+  "fileExplorerConfig": {
     "charts": {
       "data_type": {
         "chartType": "stackedBar",
@@ -276,7 +429,10 @@
     "guppyConfig": {
       "dataType": "file",
       "fieldMapping": [
-        { "field": "object_id", "name": "GUID" }
+        {
+          "field": "object_id",
+          "name": "GUID"
+        }
       ],
       "nodeCountTitle": "Files",
       "manifestMapping": {
@@ -285,7 +441,9 @@
         "referenceIdFieldInResourceIndex": "object_id",
         "referenceIdFieldInDataIndex": "object_id"
       },
-      "accessibleFieldCheckList": ["project_id"],
+      "accessibleFieldCheckList": [
+        "project_id"
+      ],
       "accessibleValidationField": "project_id",
       "downloadAccessor": "object_id"
     },


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://ctds-planx.atlassian.net/browse/PXP-8219

### Environments


### Description of changes
Added a filter for the DIscovery page to only process MDS data without a commons field.