### PR TITLE
Deploy fence 4.29.1 to PROD PRC 

### DIFF
--- a/chicagoland.pandemicresponsecommons.org/manifest.json
+++ b/chicagoland.pandemicresponsecommons.org/manifest.json
@@ -11,7 +11,7 @@
     "nb-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-nb-etl:4.7.0",
     "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.7.2",
     "covid19-bayes-model": "quay.io/cdis/covid19-bayes-model:3.4.3",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.04",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:4.29.1",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.04",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.04",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",


### PR DESCRIPTION
deploying fence version `4.29.1` to PROD PRC

https://occ-data.atlassian.net/browse/COV-929