### PR TITLE
bump just fence to 2021.06 for load testing

### DIFF
--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -12,7 +12,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:0.1.0",
     "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.05",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.05",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.06",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.05",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.05",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.05",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- BDCat Staging

### Description of changes
- bump just fence to 2021.06 for load testing