### PR TITLE
Update scaling to happen at lower CPU usage based on load testing

### DIFF
--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -276,7 +276,7 @@
       "strategy": "auto",
       "min": 2,
       "max": 20,
-      "targetCpu": 40
+      "targetCpu": 14
     },
     "indexd": {
       "strategy": "auto",


### PR DESCRIPTION


### Environments
- BDCat Staging

### Description of changes
- presigned url pods never scale up b/c the CPU doesn't reach 40% before rate limiting errors / overload (will continue to investigate underlying issue but this should help as a stop gap)