### PR TITLE
chore(jink) Update "netpolicy"=="on" for hatchery in niaiddata.org/manifest.json

### DIFF
--- a/niaiddata.org/manifest.json
+++ b/niaiddata.org/manifest.json
@@ -35,7 +35,7 @@
     "dispatcher_job_num": "10",
     "useryaml_s3path": "s3://cdis-gen3-users/nde/user.yaml",
     "origins_allow_credentials": ["https://tb.niaiddata.org", "https://aids.niaiddata.org", "https://microbiome.niaiddata.org", "https://flu.niaiddata.org"],
-    "netpolicy": "off",
+    "netpolicy": "on",
     "cookie_domain": "niaiddata.org",
     "public_datasets": true,
     "tier_access_level": "libre"


### PR DESCRIPTION
Link to Jira ticket if there is one: [Related Jira Ticket](https://ctds-planx.atlassian.net/browse/PXP-5653)

- Hatchery service would require "netpolicy" to be turned "on" in the global block of the manifest

### Environments
cdis-manifest/niaiddata.org/manifest.json

### Description of changes
- Added/ modified "netpolicy" to "on" in the "global" block of manifest.json 