### PR TITLE
chore(jink): Update "netpolicy"=="on" for hatchery in gen3-neuro.datacommons.io/manifest.json

### DIFF
--- a/gen3-neuro.datacommons.io/manifest.json
+++ b/gen3-neuro.datacommons.io/manifest.json
@@ -109,6 +109,7 @@
     "useryaml_s3path": "s3://cdis-gen3-users/oadc/user.yaml",
     "public_datasets": true,
     "tier_access_level": "libre",
+    "netpolicy": "on",
     "dispatcher_job_num": "10"
   },
   "canary": {


### PR DESCRIPTION
Link to Jira ticket if there is one: [Related Jira Ticket](https://ctds-planx.atlassian.net/browse/PXP-5653)

- Hatchery service would require "netpolicy" to be turned "on" in the global block of the manifest

### Environments
cdis-manifest/gen3-neuro.datacommons.io/manifest.json

### Description of changes
- Added/ modified "netpolicy" to "on" in the "global" block of manifest.json 