### PR TITLE
chore(bdcat): Fix refresh token api call

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -12,7 +12,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:0.1.0",
     "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.06",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.06",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:5.3.1",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.06",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.06",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.06",


### PR DESCRIPTION
This upgrade addresses the following error reported in bdcat staging:
```
  File "/fence/fence/oidc/grants/refresh_token_grant.py", line 132, in create_token_response
    scope = credential["scope"]
KeyError: 'scope'
[2021-06-29 14:59:20,122][fence.error_handler][  ERROR] 500 HTTP error occured. ID: 9105a726-9f8f-45f7-9a3b-b74c90d879f3
Details: {'message': "'scope'"}
```