### PR TITLE
fix(midrc-etl): Updated max to set, because max is only used for nume…

### DIFF
--- a/data.midrc.org/etlMapping.yaml
+++ b/data.midrc.org/etlMapping.yaml
@@ -200,7 +200,7 @@ mappings:
             fn: max
           - name: index_event
             src: index_event
-            fn: max
+            fn: set
           - name: zip
             src: zip
             fn: set

--- a/staging.midrc.org/etlMapping.yaml
+++ b/staging.midrc.org/etlMapping.yaml
@@ -200,7 +200,7 @@ mappings:
             fn: max
           - name: index_event
             src: index_event
-            fn: max
+            fn: set
           - name: zip
             src: zip
             fn: set


### PR DESCRIPTION
### Environments
MIDRC

### Description of changes
Changed max to set because max is only used for numerical numbers