### PR TITLE
chore(preprod.healdata.org): use wts 2021.06

### DIFF
--- a/preprod.healdata.org/manifest.json
+++ b/preprod.healdata.org/manifest.json
@@ -28,7 +28,7 @@
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.07",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.07",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.07",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.07"
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.06"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
As a [WTS fix](https://github.com/uc-cdis/workspace-token-service/pull/35) that would break HEAL workspaces is about to be patched to `2021.07`, downgrade HEAL Preprod WTS to `2021.06`.

### Environments
- Heal Preprod


### Description of changes
- Downgrade Heal Preprod WTS to `2021.06`