### PR TITLE
Update the auto-label for NCT PROD PR

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-      "test-portal-dataguidOrgTest": ["dataguids.org/"]
+      "test-portal-dataguidOrgTest": ["dataguids.org/"],
+      "jenkins-niaid": ["accessclinicaldata.niaid.nih.gov/"]
     }
   }


### PR DESCRIPTION
PLS NOTE -> this part needs to stay until study viewer is deployed to all the jenkins envs

```"jenkins-niaid": ["accessclinicaldata.niaid.nih.gov/"]```

