### PR TITLE
chore(ibdgc): bump fence version to address issue

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-08-05T19:49:40Z",
+  "generated_at": "2021-08-06T16:34:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5844,7 +5844,7 @@
       {
         "hashed_secret": "0da0e0005ca04acb407af2681d0bede6d9406039",
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 193,
         "type": "Secret Keyword"
       }
     ],

--- a/ibdgc.datacommons.io/manifest.json
+++ b/ibdgc.datacommons.io/manifest.json
@@ -7,7 +7,7 @@
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.07",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.07",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.07",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.08",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.07",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.07",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.07",


### PR DESCRIPTION
A single user has been experiencing an issue authenticating with Google https://github.com/uc-cdis/ibdgc-users/pull/70 and it seems this may be related to an issue addressed by https://github.com/uc-cdis/fence/releases/tag/5.3.1 (also in 2021.08 via https://github.com/uc-cdis/fence/commit/ead30a154e4216488fa3c6c591b8e252ae47f37b)

Errors from DataDog are `scope` related `KeyError: 'scope'`

### Environments

* IBGDC prod

### Description of changes

* Bump fence version to `2021.08`