### PR TITLE
preprod-heal remove gen3 documentation link

### DIFF
--- a/preprod.healdata.org/portal/gitops.json
+++ b/preprod.healdata.org/portal/gitops.json
@@ -56,10 +56,6 @@
     "topBar": {
       "items": [
         {
-          "link": "https://gen3.org/resources/user/",
-          "name": "Documentation"
-        },
-        {
           "link": "https://preprod.healdata.org/dashboard/Public/documentation/index.html",
           "name": "HEAL Documentation"
         }


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
preprod heal

### Description of changes
Remove button of Gen3 Documentation. A general link to Gen3 by CTDS is provided right in the first section of heal docs. Another link to the User Guide of Gen3 will be available in the HEAL documentation under section "downloading data files".