### PR TITLE
PXP-8448 - Register users for download

### DIFF
--- a/data.midrc.org/manifest.json
+++ b/data.midrc.org/manifest.json
@@ -8,7 +8,7 @@
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.09",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.09",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.09",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:5.4.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.09",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2021.09",

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -268,7 +268,7 @@
               "rightIcon": "download"
             }
           ],
-          "enableDownloadRegistrationLogin": true,
+          "registerUsersForDownload": true,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -268,7 +268,7 @@
               "rightIcon": "download"
             }
           ],
-          "loginForButtonFeature": true,
+          "loginForDownload": true,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",
@@ -374,7 +374,7 @@
                 "data_url_doi"
               ]
             },
-            "loginForButtonFeature": true,
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "dataset",
               "nodeCountTitle": "Datasets",
@@ -565,7 +565,7 @@
                 "rightIcon": "download"
               }
             ],
-            "loginForButtonFeature": true,
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "imaging_study",
               "nodeCountTitle": "Imaging Studies",
@@ -741,7 +741,7 @@
                 "rightIcon": "download"
               }
             ],
-            "loginForButtonFeature": true,
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "radiography_exam",
               "nodeCountTitle": "Digital Radiography Exams",
@@ -912,7 +912,7 @@
                 "rightIcon": "download"
               }
             ],
-            "loginForButtonFeature": true,
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "ct_scan",
               "nodeCountTitle": "CT Scans",
@@ -1068,7 +1068,7 @@
                 "rightIcon": "download"
               }
             ],
-            "loginForButtonFeature": true,
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "mr_exam",
               "nodeCountTitle": "MR Exams",

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -268,7 +268,7 @@
               "rightIcon": "download"
             }
           ],
-          "registerUsersForDownload": true,
+          "registerUsersForDownload": false,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -268,6 +268,7 @@
               "rightIcon": "download"
             }
           ],
+          "enableDownloadRegistrationLogin": true,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -268,7 +268,7 @@
               "rightIcon": "download"
             }
           ],
-          "registerUsersForDownload": false,
+          "loginForButtonFeature": true,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",
@@ -374,6 +374,7 @@
                 "data_url_doi"
               ]
             },
+            "loginForButtonFeature": true,
             "guppyConfig": {
               "dataType": "dataset",
               "nodeCountTitle": "Datasets",
@@ -564,6 +565,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForButtonFeature": true,
             "guppyConfig": {
               "dataType": "imaging_study",
               "nodeCountTitle": "Imaging Studies",
@@ -739,6 +741,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForButtonFeature": true,
             "guppyConfig": {
               "dataType": "radiography_exam",
               "nodeCountTitle": "Digital Radiography Exams",
@@ -909,6 +912,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForButtonFeature": true,
             "guppyConfig": {
               "dataType": "ct_scan",
               "nodeCountTitle": "CT Scans",
@@ -1064,6 +1068,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForButtonFeature": true,
             "guppyConfig": {
               "dataType": "mr_exam",
               "nodeCountTitle": "MR Exams",


### PR DESCRIPTION
Added new config variable to turn on/off loginForDownload functionality. 

Description of changes
This PR adds a configuration variable called 'loginForDownload', when this config is set to 'true' in a commons it redirects users to the login page if they try to download data before logging in. 