### PR TITLE
add role-arn to `biolincc-training-datasets-open-access` bucket

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -458,6 +458,7 @@ S3_BUCKETS:
     region: us-east-1
   biolincc-training-datasets-open-access:
     cred: fence-bot
+    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-biodata-catalyst-biolincc-phs002362-c1:
     cred: fence-bot


### PR DESCRIPTION


### Environments
- BDC PROD

### Description of changes
- add role-arn to `biolincc-training-datasets-open-access` bucket; it may be needed to allow access to this bucket, even though it should be open access