### PR TITLE
Removing auto-label for PROD NCT

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,2 @@
-jenkins-niaid:
-- any: ['accessclinicaldata.niaid.nih.gov/**/*']
 test-portal-dataguidOrgTest:
 - any: ['dataguids.org/**/*']


### PR DESCRIPTION
We dont need to auto-label PROD NCT PRs with jenkins-niaid as study-viewer has been deployed to all the jenkins envs.

All the studyViewer tests would run on all jenkins envs

