### PR TITLE
Chore/moving edc microservices to quay

### DIFF
--- a/covid19.occ-pla.net/manifest.json
+++ b/covid19.occ-pla.net/manifest.json
@@ -6,9 +6,10 @@
   "versions": {
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.07",
     "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.07",
+    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2021.07",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:4.8.2",
-    "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.7.6",
+    "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:4.9.0",
+    "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.9.0",
     "covid19-bayes-model": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-bayes-model:3.4.3",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:5.3.1",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.07",
@@ -16,7 +17,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.07",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.07",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.07",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:3.3.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:3.10.0",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.07",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.07",
@@ -27,7 +28,7 @@
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.07",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.07",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.07",
-    "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.6",
+    "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.8",
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.07",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.07"
   },
@@ -126,12 +127,20 @@
         "type": "location"
       },
       {
-        "index": "covid19_file",
-        "type": "file"
+        "index": "covid19_genomic_file",
+        "type": "genomic_file"
       },
       {
         "index": "covid19_subject",
         "type": "subject"
+      },
+      {
+        "index": "covid19_clinical_trials",
+        "type": "clinical_trials"
+      },
+      {
+        "index": "covid19_dataset",
+        "type": "dataset"
       }
     ],
     "config_index": "covid19_array-config",

--- a/portal.occ-data.org/manifest.json
+++ b/portal.occ-data.org/manifest.json
@@ -7,23 +7,23 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2020.12",
+    "arborist": "quay.io/cdis/arborist:2021.06",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2020.12",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2020.12",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2020.12",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2020.12",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2020.12",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2020.12",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2020.12",
+    "fence": "quay.io/cdis/fence:2021.06",
+    "indexd": "quay.io/cdis/indexd:2021.06",
+    "peregrine": "quay.io/cdis/peregrine:2021.06",
+    "pidgin": "quay.io/cdis/pidgin:2021.06",
+    "revproxy": "quay.io/cdis/nginx:2021.06",
+    "sheepdog": "quay.io/cdis/sheepdog:2021.06",
+    "portal": "quay.io/cdis/data-portal:2021.06",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2020.12",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2020.12",
-    "nb2": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nb2:2020.12",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2020.12",
+    "spark": "quay.io/cdis/gen3-spark:2021.06",
+    "tube": "quay.io/cdis/tube:2021.06",
+    "nb2": "quay.io/cdis/nb2:2021.06",
+    "hatchery": "quay.io/cdis/hatchery:2021.06",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2020.12",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2020.12"
+    "wts": "quay.io/cdis/workspace-token-service:2021.06",
+    "manifestservice": "quay.io/cdis/manifestservice:2021.06"
   },
   "arborist": {
     "deployment_version": "2"
@@ -38,7 +38,7 @@
     "sidecar": {
       "cpu-limit": "1.0",
       "memory-limit": "256Mi",
-      "image": "quay.io/cdis/gen3fuse-sidecar:2020.12",
+      "image": "quay.io/cdis/gen3fuse-sidecar:2021.06",
       "env": {
         "NAMESPACE": "default",
         "HOSTNAME": "portal.occ-data.org"


### PR DESCRIPTION
### Environments
portal.occ-data.org
covid19.occ-pla.net

### Description of changes
#### EDC (Portal)
Changed manifest.json to pull images from quay
upgraded micro service versions from 2020.12 to 2021.06

#### PRC QA OCC (covid19.occ-pla.net)
upgraded micro service versions
added indexes for guppy