### PR TITLE
chore(ibdgc_fence-config-public)Adding ORCID Login option for IBDGC

### DIFF
--- a/ibdgc.datacommons.io/manifests/fence/fence-config-public.yaml
+++ b/ibdgc.datacommons.io/manifests/fence/fence-config-public.yaml
@@ -133,7 +133,10 @@ ITRUST_GLOBAL_LOGOUT: 'https://auth.nih.gov/siteminderagent/smlogout.asp?mode=ni
 LOGIN_OPTIONS:
   - name: 'Login from Google'
     idp: google
-
+  - name: 'ORCID Login'
+    idp: fence
+    fence_idp: orcid
+    secondary: False
 # Default login provider:
 # - must be configured in LOGIN_OPTIONS and OPENID_CONNECT
 # - if several options in LOGIN_OPTIONS are defined for this IDP, will default


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/GPE-160

### Environments
ibdgc.datacommons.io

### Description of changes
ibdgc commons uses a public fence config, so updating fence-config-public.yaml to add the ORCID login.