### PR TITLE
Add release-10 s3 buckets to BDC preprod fence config

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -633,3 +633,6 @@ S3_BUCKETS:
   nih-nhlbi-pcgc-phs001843-c1:
     cred: fence-bot
     region: us-east-1
+  nih-nhlbi-topmed-released-phs001600-c1:
+    cred: fence-bot
+    region: us-east-1


### PR DESCRIPTION

### Environments
- preprod.gen3.biodatacatalyst.nhlbi.nih.gov

### Description of changes
- add new s3 buckets from BDC data release 10 to preprod fence config
