### PR TITLE
Add new s3 buckets to BDC PROD fence config

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -33,6 +33,9 @@ S3_BUCKETS:
     cred: fence-bot
     role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
+  nih-nhlbi-topmed-released-phs001600-c1:
+    cred: fence-bot
+    region: us-east-1
   nih-nhlbi-covid19-phs002299-c1:
     cred: fence-bot
     role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene

--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -36,6 +36,7 @@ S3_BUCKETS:
   nih-nhlbi-topmed-released-phs001600-c1:
     cred: fence-bot
     region: us-east-1
+    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
   nih-nhlbi-covid19-phs002299-c1:
     cred: fence-bot
     role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene


### PR DESCRIPTION
### Environments
- gen3.biodatacatalyst.nhlbi.nih.gov


### Description of changes
- Add new s3 buckets for BDC release 10 to BDC PROD fence config