### PR TITLE
KF staging: new NIH entityID

### DIFF
--- a/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -112,6 +112,7 @@ LOGIN_OPTIONS:  # !!! remove the empty list to enable login options!
     idp: google
   - name: 'NIH Login'
     idp: fence
+    fence_idp: shibboleth
     shib_idps:
       - https://auth.nih.gov/IDP
   - name: 'Login from RAS'

--- a/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -112,6 +112,8 @@ LOGIN_OPTIONS:  # !!! remove the empty list to enable login options!
     idp: google
   - name: 'NIH Login'
     idp: fence
+    shib_idps:
+      - https://auth.nih.gov/IDP
   - name: 'Login from RAS'
     idp: ras
   - name: 'ORCID Login'


### PR DESCRIPTION
Link to Jira ticket if there is one:

external qa: #3770

### Environments
KF staging

### Description of changes
- default/old NIH entityID (`urn:mace:incommon:nih.gov`) is broken for NIH employees
- new NIH entityID (`https://auth.nih.gov/IDP`) was added manually, but that broke the old one, so users can't login through NIH anymore
- => use the NIH entityID