### PR TITLE
KF external QA: new NIH entityID

### DIFF
--- a/gen3qa.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/gen3qa.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -112,6 +112,9 @@ LOGIN_OPTIONS:  # !!! remove the empty list to enable login options!
     secondary: True
   - name: 'NIH Login'
     idp: fence
+    fence_idp: shibboleth
+    shib_idps:
+      - https://auth.nih.gov/IDP
   - name: 'Login from RAS'
     idp: ras
 


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
KF external QA

### Description of changes
- default/old NIH entityID (`urn:mace:incommon:nih.gov`) is broken for NIH employees
- new NIH entityID (`https://auth.nih.gov/IDP`) was added manually, but that broke the old one, so users can't login through NIH anymore
- => use the NIH entityID