### PR TITLE
KF prod: new NIH entityID

### DIFF
--- a/data.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/data.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -108,6 +108,9 @@ DEFAULT_LOGIN_IDP: fence
 LOGIN_OPTIONS:  # !!! remove the empty list to enable login options!
   - name: 'NIH Login'
     idp: fence
+    fence_idp: shibboleth
+    shib_idps:
+      - https://auth.nih.gov/IDP
   - name: 'Login from RAS'
     idp: ras
   - name: 'ORCID Login'


### PR DESCRIPTION
Link to Jira ticket if there is one:

staging: #3769

### Environments
KF prod

### Description of changes
- default/old NIH entityID (`urn:mace:incommon:nih.gov`) is broken for NIH employees
- new NIH entityID (`https://auth.nih.gov/IDP`) was added manually, but that broke the old one, so users can't login through NIH anymore
- => use the new entityID