### PR TITLE
[PXP-9196] Add HHS Responsible Disclosure link to BDC Preprod

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/portal/gitops.json
@@ -157,6 +157,10 @@
           "text": "Data Sharing Policy"
         },
         {
+          "text": "HHS Responsible Disclosure Form",
+          "href": "https://hhs.responsibledisclosure.com/hc/en-us"
+        },
+        {
           "text": "Freedom of Information Act (FOIA)",
           "href": "https://www.nhlbi.nih.gov/about/foia-fee-for-service-office"
         },


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-9196
> All NIH websites must be updated with the HHS Responsible Disclosure redirect link to provide the public with guidance on how to report a discovered vulnerability on your website by 19-Jan-2022.

### Environments
- BDC Preprod


### Description of changes
- Add HHS Responsible Disclosure link to BDC Preprod
