### PR TITLE
changed tier_access_level to private

### DIFF
--- a/validate.midrc.org/manifest.json
+++ b/validate.midrc.org/manifest.json
@@ -173,8 +173,7 @@
     "sync_from_dbgap": "False",
     "netpolicy": "on",
     "public_datasets": true,
-    "tier_access_level": "regular",
-    "tier_access_limit": "50",
+    "tier_access_level": "private",
     "maintenance_mode": "off",
     "dd_enabled": true
   },


### PR DESCRIPTION
This commons should be private and not display any counts or numbers for properties on the homepage or explorer unless a user is logged in and authorized.