### PR TITLE
disable mariner in vhdcprod

### DIFF
--- a/va.data-commons.org/manifest.json
+++ b/va.data-commons.org/manifest.json
@@ -16,7 +16,6 @@
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2021.12",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.12",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.12",
-    "mariner": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/mariner-server:2021.12",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.12",
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:master-2.8-manconf",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:master-2.8",


### PR DESCRIPTION
### Environments
vhdcprod

### Description of changes
mariner will no longer be used as the backend workflow engine of VA so we are removing it from use