### PR TITLE
Add HHS link to kidsfirst footer

### DIFF
--- a/dcf-interop.kidsfirstdrc.org/portal/gitops.json
+++ b/dcf-interop.kidsfirstdrc.org/portal/gitops.json
@@ -106,6 +106,15 @@
       "email": "support@kidsfirstdrc.org"
     }
   },
+  
+  "footer": {
+    "links": [
+      {
+        "text": "HHS Responsible Disclosure Form",
+        "href": "https://hhs.responsibledisclosure.com/hc/en-us"
+      }
+    ]
+  },
   "featureFlags": {
     "explorer": false
   }


### PR DESCRIPTION
Link to Jira ticket if there is one: [PXP-9245](https://ctds-planx.atlassian.net/browse/PXP-9245)

### Environments
- KidsFirst

### Description of changes
- Add HHS link to KidsFirst footer 