### PR TITLE
Fix: Update dictionary to 4.2.0

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -402,7 +402,7 @@
     "environment": "stageprod",
     "hostname": "preprod.gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/a82bb5ed-9ad1-444d-9bfd-5bc314541307",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.1.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.2.0/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",


### PR DESCRIPTION
Dictionary 4.2.0 reverts a breaking change made in 4.0.12 that's causing PFB exports to break.

Link to Jira ticket if there is one:

### Environments
- BDC Preprod

### Description of changes
- Update dictionary to 4.2.0 to revert a breaking change made in 4.0.12.
