### PR TITLE
BDCat preprod: Update dictionary for Activ4a race property workaround

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -402,7 +402,7 @@
     "environment": "stageprod",
     "hostname": "preprod.gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/a82bb5ed-9ad1-444d-9bfd-5bc314541307",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.2.0/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.2.1/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",


### PR DESCRIPTION
This is a workaround for the fact that the Activ4a data has subjects with multiple values in the race property. We need to change the property to an array, but as that's a breaking change we'll need to resubmit all the data in sheepdog when we do that, so we need to plan ahead.

### Environments
- BDC preprod

### Description of changes
