### PR TITLE
v0.6.6: reverting back to only changes needing to go to production

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -168,7 +168,7 @@
     "kube_bucket": "kube-midrcprod-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcprod-gen3",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.6.5/schema.json",
+    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.6.6/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
In the 0.6.5 release, there were clinical changes that needed to move to production right away and imaging modality and annotation changes that are still in discussion. This release is to get us back to only items that are ready to move to production.

See details here: https://github.com/uc-cdis/midrc_dictionary/pull/73