### PR TITLE
updated MIDRD staging dictionary to 0.6.8

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -168,7 +168,7 @@
     "kube_bucket": "kube-midrcprod-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcprod-gen3",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.6.7/schema.json",
+    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.6.8/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
Needed to change the node category of mr_series_file to "imaging_data_file" (formerly "imaging_series") to support the ETL of GUIDs.