### PR TITLE
MIDRC Codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,9 +10,9 @@ gen3-neuro.datacommons.io @jingh8 @uc-cdis/planx-qa
 va-testing.datacommons.io @nmetokishlubsky @uc-cdis/planx-qa
 va.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 vpodc.org @nmetokishlubsky @uc-cdis/planx-qa
-data.midrc.org @lynettelilly @cgmeyer @uc-cdis/planx-qa
-staging.midrc.org @lynettelilly @cgmeyer @uc-cdis/planx-qa
-validate.midrc.org @lynettelilly @cgmeyer @uc-dis/planx-qa
+data.midrc.org @trevars @cgmeyer @uc-cdis/planx-qa
+staging.midrc.org @trevars @cgmeyer @uc-cdis/planx-qa
+validate.midrc.org @trevars @cgmeyer @uc-dis/planx-qa
 
 gen3.theanvil.io @radhrreddy @uc-cdis/planx-qa
 staging.theanvil.io @radhrreddy @uc-cdis/planx-qa


### PR DESCRIPTION
Lynette --> Trevar, because teamwork

Link to Jira ticket if there is one:

### Environments
All midrc

### Description of changes
Codeowner, replace Lynette with Trevar