### PR TITLE
fix: correct vpodc domain/folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@ gen3-neuro.datacommons.io @jingh8 @uc-cdis/planx-qa
 
 va-testing.datacommons.io @nmetokishlubsky @uc-cdis/planx-qa
 va.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
-vpodc.org @nmetokishlubsky @uc-cdis/planx-qa
+vpodc.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 
 data.midrc.org @trevars @cgmeyer @uc-cdis/planx-qa
 staging.midrc.org @trevars @cgmeyer @uc-cdis/planx-qa


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
* vpodc.data-commons.org

### Description of changes
* correct folder in CODEOWNERS