### PR TITLE
Updated BloodPAC publication_url contentType

### DIFF
--- a/data.bloodpac.org/portal/gitops.json
+++ b/data.bloodpac.org/portal/gitops.json
@@ -1062,7 +1062,7 @@
     {
       "name": "Publication URL",
       "field": "publication_url",
-      "contentType": "string"
+      "contentType": "link"
     },
     {
       "name": "Condition",


### PR DESCRIPTION
Link to Jira ticket if there is one: [PXP-9643](https://ctds-planx.atlassian.net/browse/PXP-9643)

### BloodPAC


### Changed publication url contentType from "string" to "link" in order to have publication urls be presented as hyperlinks instead of strings per BloodPAC request. 
