### PR TITLE
Update bloodpac gitops.json

### DIFF
--- a/data.bloodpac.org/portal/gitops.json
+++ b/data.bloodpac.org/portal/gitops.json
@@ -1105,7 +1105,7 @@
             {
               "name": "Publication URL",
               "field": "publication_url",
-              "contentType": "string"
+              "contentType": "link"
             },
             {
               "name": "Data Availability Date",


### PR DESCRIPTION
Link to Jira ticket if there is one: [PXP-9643](https://ctds-planx.atlassian.net/browse/PXP-9643)

### BloodPAC 


### Had absentmindedly updated publication_url contentType from "string" to "url" instead of the appropriate "link" which crashed study page [PR-4312](https://github.com/uc-cdis/cdis-manifest/pull/4312), then reverted those changes [PR-4317](https://github.com/uc-cdis/cdis-manifest/pull/4317), now returning after figuring out the source of the error and correcting it.
