### PR TITLE
edit GDC entry in BRH agg_metadata config

### DIFF
--- a/brh.data-commons.org/metadata/aggregate_config.json
+++ b/brh.data-commons.org/metadata/aggregate_config.json
@@ -68,7 +68,6 @@
     "Genomic Data Commons": {
       "mds_url": "https://gen3.datacommons.io",
       "commons_url": "portal.gdc.cancer.gov",
-      "study_data_field": "discovery_metadata",
       "columns_to_fields": {
         "_subjects_count": "subjects_count",
         "dbgap_accession_number": "study_id",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments


### Description of changes
Fixed GDC's entry in aggregate_metadata so GDC entries can be read from gen3.datacommons.io