### PR TITLE
Changing documentation link to gen3 client docs

### DIFF
--- a/va.data-commons.org/portal/gitops.json
+++ b/va.data-commons.org/portal/gitops.json
@@ -98,8 +98,8 @@
             "name": "Submit Data"
           },
           {
-            "link": "https://gen3.org/resources/user/",
-            "name": "Documentation"
+            "link": "https://gen3.org/resources/user/gen3-client/",
+            "name": "Gen3 Client tutorial"
           },
           {
             "link": "support@datacommons.io",


### PR DESCRIPTION
...as a follow-up of https://github.com/uc-cdis/gitops-qa/pull/1931

Link to Jira ticket if there is one: n/a

### Environments

PROD VA

### Description of changes
We wanted a different link to appear on top-right instead of "Documentation". This new link takes user to the gen3 client docs, so they can easily find information on how to extract the GWAS workflow output files.
