### PR TITLE
use copy branch for dcf datareplicate service

### DIFF
--- a/nci-crdc.datacommons.io/manifest.json
+++ b/nci-crdc.datacommons.io/manifest.json
@@ -11,7 +11,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2022.03",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2022.03",
-    "datareplicate": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/dcf-dataservice:2022.03",
+    "datareplicate": "quay.io/cdis/dcf-dataservice:chore_just_copy",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2022.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "google-sa-validation": "placeholder:2022.03",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- nci.crdc prod

### Description of changes
- Use copy branch for dcf-datareplicate service, to only copy files and not index for aws replicate process