### PR TITLE
MIDRC staging: fix Imaging Series manifest

### DIFF
--- a/staging.midrc.org/portal/gitops.json
+++ b/staging.midrc.org/portal/gitops.json
@@ -732,7 +732,7 @@
               },
               {
                 "enabled": true,
-                "type": "manifest",
+                "type": "file-manifest",
                 "title": "Download File Manifest",
                 "leftIcon": "datafile",
                 "rightIcon": "download",
@@ -761,8 +761,6 @@
                 }
               ],
               "manifestMapping": {
-                "resourceIndexType": "imaging_data_file",
-                "resourceIdField": "object_id",
                 "referenceIdFieldInResourceIndex": "object_id",
                 "referenceIdFieldInDataIndex": "object_id"
               },


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
MIDRC staging

### Description of changes
Fix the "Imaging Series" "download file manifest" button to generate a manifest of `{ "object_id": "abc" }`
instead of `{ "object_id": [ "abc" ] }`