### PR TITLE
fix(bdc-preprod-file-access): Removed assume role for buckets that fa…

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -37,7 +37,6 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000007-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000007-c2:
     cred: fence-bot
@@ -45,11 +44,9 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000179-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000179-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000200-c1:
     cred: fence-bot
@@ -57,15 +54,12 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000200-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000209-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000209-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000280-c1:
     cred: fence-bot
@@ -77,31 +71,24 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000284-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c3:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c4:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000287-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000287-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000287-c3:
     cred: fence-bot
@@ -109,7 +96,6 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000287-c4:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000289-c1:
     cred: fence-bot
@@ -121,15 +107,12 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000784-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000820-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000914-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000920-c2:
     cred: fence-bot
@@ -365,23 +348,18 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000166-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000422-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000703-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000810-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000810-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs001012-c1:
     cred: fence-bot


### PR DESCRIPTION
### Environments
BDC preprod

### Description of changes
Removed assume role for buckets that failed gen3qa access check