### PR TITLE
[PXP-9175] Add `dd_enabled : true` flag in KidsFirst Manifest

### DIFF
--- a/data.kidsfirstdrc.org/manifest.json
+++ b/data.kidsfirstdrc.org/manifest.json
@@ -38,7 +38,8 @@
     "sync_from_dbgap": "True",
     "netpolicy": "on",
     "slack_send_dbgap": "True",
-    "maintenance_mode": "off"
+    "maintenance_mode": "off",
+    "dd_enabled": true
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
Link to Jira ticket if there is one: [PXP-9175](https://ctds-planx.atlassian.net/browse/PXP-9175)

### Environments
* KidsFirst data commons

### Description of changes
* Add `dd_enabled : true` flag

[PXP-9175]: https://ctds-planx.atlassian.net/browse/PXP-9175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ