### PR TITLE
probably need to revert a7ecf29d0706092f46dfcb3e0ebc6053a8400f02 for …

### DIFF
--- a/brh.data-commons.org/metadata/aggregate_config.json
+++ b/brh.data-commons.org/metadata/aggregate_config.json
@@ -108,7 +108,7 @@
   },
   "adapter_commons": {
     "Kids First": {
-      "mds_url": "https://gen3staging.kidsfirstdrc.org",
+      "mds_url": "https://gen3staging.kidsfirstdrc.org/",
       "commons_url": "kidsfirstdrc.org",
       "adapter": "gen3",
       "config": {


### PR DESCRIPTION
mds URL is incorrect for kids first data commons when a metadata sync job is run. This PR tests if adding the `/` back helps with the issue. This is reverting the previous commit https://github.com/uc-cdis/cdis-manifest/commit/a7ecf29d0706092f46dfcb3e0ebc6053a8400f02

Link to Jira ticket if there is one:

### Environments


### Description of changes
