### PR TITLE
chore/update_niaid-portal: update niaid data-portal image to 3.30.0

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -16,7 +16,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2022.07",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2022.07",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2022.07",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:3.29.1",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2022.08.1",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2022.07",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2022.07",

--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -16,7 +16,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2022.07",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2022.07",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2022.07",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2022.08.1",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:3.30.0",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2022.07",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2022.07",


### PR DESCRIPTION
### Environments
NIAID

### Description of changes
## New Features
  - add cohort overlap to case control gwas (#1068)
  - [move submitted workflows to separate app 
    ](https://ctds-planx.atlassian.net/browse/VADC-41) (#1068)
  - add text box callout to nct home page right column (#1065)
  - additional react tour (#1066)
  - show info message when user is not logged in with correct credentials 
    (#1062)
  - add header for dichotomous variable step (#1060)
  - latest gwas ui post-refactor (#1054)

## Bug Fixes
  - [PXP-113](https://ctds-planx.atlassian.net/browse/VADC-113) (#1068)
  - [PXP-114](https://ctds-planx.atlassian.net/browse/VADC-114) (#1068)
  - Fixes pagination settings to allow the "size changer" to work again (#1063)

## Dependency Updates
  - sync w/ master on removing babel-eslint (#1054)