### PR TITLE
JCOIN added the etl'ed time point index to manifest

### DIFF
--- a/jcoin.datacommons.io/manifest.json
+++ b/jcoin.datacommons.io/manifest.json
@@ -182,6 +182,11 @@
       {
         "index": "jcoin_saes",
         "type": "serious_adverse_event"
+
+      },
+      {
+        "index": "jcoin_etl_time_points",
+        "type": "time_point"
       }
     ],
     "config_index": "jcoin_array-config",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
PROD

### Description of changes
Additional update to manifest.json: added guppy time point index used by one of the explorer tabs 
Deployed QA PR is [here](https://github.com/uc-cdis/gitops-qa/pull/2022/files#diff-4adde167f8faa3dd3902be286f6a6b05d9842ee198e1af2fef3f32a02b220b0e)