### PR TITLE
JCOIN login page title: "portal" to "data commons"

### DIFF
--- a/jcoin.datacommons.io/portal/gitops.json
+++ b/jcoin.datacommons.io/portal/gitops.json
@@ -123,7 +123,7 @@
       ]
     },
     "login": {
-      "title": "JCOIN Portal",
+      "title": "JCOIN Data Commons",
       "subTitle": "The JCOIN Data Commons provides the management, analysis, and sharing of JCOIN data to support the JCOIN research community, goals, and vision.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io",

--- a/jcoin.datacommons.io/portal/gitops.json
+++ b/jcoin.datacommons.io/portal/gitops.json
@@ -17,7 +17,7 @@
     "projectDetails": "boardCounts"
   },
   "components": {
-    "appName": "JCOIN Portal",
+    "appName": "JCOIN Data Commons",
     "index": {
       "introduction": {
         "heading": "JCOIN Data Commons",


### PR DESCRIPTION

### Environments
PROD

### Description of changes
changing title reduces confusion with other JCOIN portals like CTC JCOIN portal

see QA PR [here](https://github.com/uc-cdis/gitops-qa/pull/2190)