### PR TITLE
MIDRC_v0.7.9: adding Indeterminate to COVID props and removing harmonized study description

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -162,7 +162,7 @@
     "kube_bucket": "kube-midrcprod-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcprod-gen3",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.7.8/schema.json",
+    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/0.7.9/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
The updates in this release include 1.) adding "Indeterminate" to the COVID-related properties and 2.) removing the imaging_study property midrc_harmonized_study_description because it is not needed.

Details for these changes can be found in the tickets below:

https://ctds-planx.atlassian.net/browse/MIDRC-66
https://ctds-planx.atlassian.net/jira/software/projects/MIDRC/boards/133?selectedIssue=MIDRC-57
