### PR TITLE
Updating brhstaging manifest to work with Portal v5

### DIFF
--- a/brhstaging.data-commons.org/manifest.json
+++ b/brhstaging.data-commons.org/manifest.json
@@ -15,14 +15,16 @@
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "hatchery": "quay.io/cdis/hatchery:1.0.0",
     "indexd": "quay.io/cdis/indexd:2022.06",
+    "kayako-wrapper": "quay.io/cdis/kayako-wrapper-service:0.1.1",
     "manifestservice": "quay.io/cdis/manifestservice:2022.06",
     "metadata": "quay.io/cdis/metadata-service:BRH-1.0.0",
     "peregrine": "quay.io/cdis/peregrine:2022.06",
     "pidgin": "quay.io/cdis/pidgin:2022.06",
-    "portal": "quay.io/cdis/data-portal:feat_agg-mds-true-access-brh-changes",
+    "portal": "quay.io/cdis/data-portal:5.0.0",
+    "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:1.7.1",
     "revproxy": "quay.io/cdis/nginx:2022.06",
     "sheepdog": "quay.io/cdis/sheepdog:2022.06",
-    "wts": "quay.io/cdis/workspace-token-service:0.4.0"
+    "wts": "quay.io/cdis/workspace-token-service:0.4.1"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
* BRHStaging

### Description of changes
* Updated Portal to 5.0.0
* Added/updated requestor, kayako-wrapper-service and wts to work with the new workspace registration feature in 5.0.0