### PR TITLE
Update dictionary url to 4.3.1

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -401,7 +401,7 @@
     "environment": "stageprod",
     "hostname": "preprod.gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/a82bb5ed-9ad1-444d-9bfd-5bc314541307",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.3.0/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.3.1/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
preprod.gen3.biodatacatalyst.nhlbi.nih.gov

### Description of changes
pointing dictionary url to new schema .json