### PR TITLE
VADC-208: Fix documentation link

### DIFF
--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -42,7 +42,7 @@
       "topBar": {
         "items": [
           {
-            "link": "https://va.data-commons.org/dashboard/Public/documentation/index.html",
+            "link": "https://va-testing.data-commons.org/dashboard/Public/documentation/index.html",
             "name": "VADC Documentation"
           },
           {


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-208](https://ctds-planx.atlassian.net/browse/VADC-208)

### Environments
* va-testing.data-commons.org


### Description of changes
* Fixed the documentation link