### PR TITLE
feat: va-testing.data-commons.org is the proper domain

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@ dcf-interop.kidsfirstdrc.org @trevars @uc-cdis/planx-qa
 tbi.datacommons.io @trevars @jingh8 @uc-cdis/planx-qa
 gen3-neuro.datacommons.io @trevars @jingh8 @uc-cdis/planx-qa
 
-va-testing.datacommons.io @nmetokishlubsky @uc-cdis/planx-qa
+va-testing.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 va.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 vpodc.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 


### PR DESCRIPTION
Link to Jira ticket if there is one: N/A

### Environments
* N/A

### Description of changes
* proper domain for VA testing environment