### PR TITLE
added dicom viewer to midrc

### DIFF
--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -634,7 +634,11 @@
           "case_ids",
           "object_id",
           "project_id"
-        ]
+        ],
+        "dicomViewerId": "submitter_id",
+                "linkFields": [
+                "submitter_id"
+              ]
       },
       "dropdowns": {
         "download-table": {
@@ -694,6 +698,10 @@
             "field": "project_id",
             "name": "Project ID"
           },
+          {
+            "field": "submitter_id",
+            "name": "Browse in DICOM viewer"
+         },
           {
             "field": "case_ids",
             "name": "Patient ID"


### PR DESCRIPTION
Adding dicom viewer to data.midrc.or

### Environments
Data.midrc.org

### Description of changes
When the user clicks on explorer page under imaging studies tab users click on the dicom viewer icon to launch studies in dicom viewer