### PR TITLE
Remove SESSION_TIMEOUT override

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/accessclinicaldata.niaid.nih.gov/manifests/fence/fence-config-public.yaml
@@ -94,9 +94,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/chicagoland.pandemicresponsecommons.org/manifests/fence/fence-config-public.yaml
+++ b/chicagoland.pandemicresponsecommons.org/manifests/fence/fence-config-public.yaml
@@ -180,9 +180,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/data.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/data.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -54,9 +54,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/gen3qa.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/gen3qa.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -55,9 +55,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
+++ b/gen3staging.kidsfirstdrc.org/manifests/fence/fence-config-public.yaml
@@ -55,9 +55,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/ibdgc.datacommons.io/manifests/fence/fence-config-public.yaml
+++ b/ibdgc.datacommons.io/manifests/fence/fence-config-public.yaml
@@ -73,9 +73,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/jcoin.datacommons.io/manifests/fence/fence-config-public.yaml
+++ b/jcoin.datacommons.io/manifests/fence/fence-config-public.yaml
@@ -71,9 +71,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
niaid, ibd, jcoin, covid19, kidsfirst (external qa, staging, prod)

### Description of changes
remove SESSION_TIMEOUT fence config override so we fall back on the default