### PR TITLE
fix(VADC-220): revert to legacy UA ID

### DIFF
--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -1,5 +1,5 @@
 {
-  "gaTrackingId": "G-C3XGQPXLJ3",
+  "gaTrackingId": "UA-119127212-21",
   "argoTemplate": "gwas-test-curation",
   "graphql": {
     "boardCounts": [],


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments

* va-testing

### Description of changes

* Update GA tracking but using legacy UA IDs