### PR TITLE
BRH-295

### DIFF
--- a/brh.data-commons.org/metadata/aggregate_config.json
+++ b/brh.data-commons.org/metadata/aggregate_config.json
@@ -183,7 +183,7 @@
 				"commons_url" : "gen3.theanvil.io"
 			}
 		},
-		"Genomic Data Commons": {
+		"CRDC Genomic Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "portal.gdc.cancer.gov",
 			"config" : {
@@ -208,7 +208,7 @@
 				"commons_url" : "brh.data-commons.org"
 			}
 		},
-		"Proteomic Data Commons": {
+		"CRDC Proteomic Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "proteomic.datacommons.cancer.gov/pdc",
 			"config" : {
@@ -233,7 +233,7 @@
 				"commons_url" : "proteomic.datacommons.cancer.gov/pdc"
 			}
 		},
-		"Cancer Imaging Data Commons": {
+		"CRDC Cancer Imaging Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "imaging.datacommons.cancer.gov",
 			"config" : {
@@ -282,7 +282,7 @@
 				"commons_url" : "gen3.datacommons.io"
 			}
 		},
-		"Canine Data Commons": {
+		"Tutorial Canine Data Commons": {
       			"mds_url": "https://caninedc.org/",
       			"commons_url": "caninedc.org",
       			"config": {

--- a/brhstaging.data-commons.org/metadata/aggregate_config.json
+++ b/brhstaging.data-commons.org/metadata/aggregate_config.json
@@ -183,7 +183,7 @@
 				"commons_url" : "gen3.theanvil.io"
 			}
 		},
-		"Genomic Data Commons": {
+		"CRDC Genomic Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "portal.gdc.cancer.gov",
 			"config" : {
@@ -208,7 +208,7 @@
 				"commons_url" : "brh.data-commons.org"
 			}
 		},
-		"Proteomic Data Commons": {
+		"CRDC Proteomic Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "proteomic.datacommons.cancer.gov/pdc",
 			"config" : {
@@ -233,7 +233,7 @@
 				"commons_url" : "proteomic.datacommons.cancer.gov/pdc"
 			}
 		},
-		"Cancer Imaging Data Commons": {
+		"CRDC Cancer Imaging Data Commons": {
 			"mds_url": "https://brh.data-commons.org/",
 			"commons_url" : "imaging.datacommons.cancer.gov",
 			"config" : {
@@ -282,7 +282,7 @@
 				"commons_url" : "gen3.datacommons.io"
 			}
 		},
-		"Canine Data Commons": {
+		"Tutorial Canine Data Commons": {
       			"mds_url": "https://caninedc.org/",
       			"commons_url": "caninedc.org",
       			"config": {


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/BRH-295

The “CRDC” prefix should appear in the names of the following data commons in BRH:

Genomic Data Commons

Cancer Imaging Data Commons

Proteomic Data Commons

Add “Tutorial” to Canine Commons as that’s what the data is.