### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,8 +43,8 @@ accessclinicaldata.niaid.nih.gov @hughestr @uc-cdis/planx-qa
 
 gen3.datacommons.io @trevars @cgmeyer @uc-cdis/planx-qa
 
-portal.occ-data.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ @divyaocc
-data.bloodpac.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ @divyaocc
+portal.occ-data.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ
+data.bloodpac.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ
 
 healdata.org @hughestr @uc-cdis/planx-qa
 preprod.healdata.org @hughestr @uc-cdis/planx-qa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,6 @@ acct.bionimbus.org @trevars @uc-cdis/planx-qa
 caninedc.org @trevars @uc-cdis/planx-qa
 dataguids.org @trevars @uc-cdis/planx-qa
 genomel.bionimbus.org @trevars @uc-cdis/planx-qa
-nci-crdc-staging.datacommons.io @trevars @uc-cdis/planx-qa
-nci-crdc.datacommons.io @trevars @uc-cdis/planx-qa
 internal-icgc.bionimbus.org @trevars @uc-cdis/planx-qa
 icgc.bionimbus.org @trevars @uc-cdis/planx-qa
 aids.diseasedatahub.org @trevars @uc-cdis/planx-qa
@@ -11,6 +9,9 @@ tb.diseasedatahub.org @trevars @uc-cdis/planx-qa
 flu.diseasedatahub.org @trevars @uc-cdis/planx-qa
 diseasedatahub.org @trevars @uc-cdis/planx-qa
 dcf-interop.kidsfirstdrc.org @trevars @uc-cdis/planx-qa
+
+nci-crdc-staging.datacommons.io @trevars @uc-cdis/planx-qa
+nci-crdc.datacommons.io @trevars @uc-cdis/planx-qa
 
 tbi.datacommons.io @trevars @uc-cdis/planx-qa
 gen3-neuro.datacommons.io @trevars @uc-cdis/planx-qa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@ flu.diseasedatahub.org @trevars @uc-cdis/planx-qa
 diseasedatahub.org @trevars @uc-cdis/planx-qa
 dcf-interop.kidsfirstdrc.org @trevars @uc-cdis/planx-qa
 
-nci-crdc-staging.datacommons.io @trevars @uc-cdis/planx-qa
-nci-crdc.datacommons.io @trevars @uc-cdis/planx-qa
+nci-crdc-staging.datacommons.io @frankliuao @uc-cdis/planx-qa
+nci-crdc.datacommons.io @frankliuao @uc-cdis/planx-qa
 
 tbi.datacommons.io @trevars @uc-cdis/planx-qa
 gen3-neuro.datacommons.io @trevars @uc-cdis/planx-qa


### PR DESCRIPTION
Removed divya-occ from occ-data & bloodpac
Replace Trevar with Ao on DCF & DCF Staging

### Environments
portal.occ-data.org & data.bloodpac.org
nci-crdc-staging.datacommons.io & nci-crdc.datacommons.io

### Description of changes
Changing code owners