### PR TITLE
Update etlmapping for 2022.11

### DIFF
--- a/acct.bionimbus.org/etlMapping.yaml
+++ b/acct.bionimbus.org/etlMapping.yaml
@@ -147,7 +147,6 @@ mappings:
     root: None
     category: data_file
     props:
-      - name: project_id
       - name: submitter_id
       - name: object_id
       - name: md5sum

--- a/chorus.data-commons.org/etlMapping.yaml
+++ b/chorus.data-commons.org/etlMapping.yaml
@@ -52,7 +52,6 @@ mappings:
       - name: data_format
       - name: data_type
       - name: data_category
-      - name: project_id
       - name: analysis_type
       - name: experimental_strategy
       - name: donor_barcode

--- a/flu.diseasedatahub.org/etlMapping.yaml
+++ b/flu.diseasedatahub.org/etlMapping.yaml
@@ -129,6 +129,7 @@ mappings:
       - name: weight_percentage
       - name: tint
       - name: days_to_follow_up
+      - name: project_id
   - name: flu_file
     doc_type: file
     type: collector

--- a/icgc.bionimbus.org/etlMapping.yaml
+++ b/icgc.bionimbus.org/etlMapping.yaml
@@ -52,7 +52,6 @@ mappings:
       - name: data_format
       - name: data_type
       - name: data_category
-      - name: project_id
       - name: analysis_type
       - name: experimental_strategy
       - name: donor_barcode

--- a/internal-icgc.bionimbus.org/etlMapping.yaml
+++ b/internal-icgc.bionimbus.org/etlMapping.yaml
@@ -52,7 +52,6 @@ mappings:
       - name: data_format
       - name: data_type
       - name: data_category
-      - name: project_id
       - name: analysis_type
       - name: experimental_strategy
       - name: donor_barcode


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
acct.bionimbus.org
chorus.data-commons.org
flu.diseasedatahub.org -- added project_id to follow-up
icgc.bionimbus.org
internal-icgc.bionimbus.org

### Description of changes
Removed project_id from files > props
For flu.diseasedatahub.org only, added project_id to follow-up