### PR TITLE
Documentation

### DIFF
--- a/brhstaging.data-commons.org/portal/gitops.json
+++ b/brhstaging.data-commons.org/portal/gitops.json
@@ -65,7 +65,7 @@
     "topBar": {
       "items": [
         {
-          "link": "https://brhstaging.data-commons.org/dashboard/Public/index.html",
+          "link": "https://uc-cdis.github.io/BRH-documentation/home/",
           "name": "Documentation"
         }
       ]


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/BRH-356

Environments
BRH Staging

Description of changes
change the documentation link in line 68 of portal/gitops.json to point to the new MkDocs documentation (https://uc-cdis.github.io/BRH-documentation/home/) instead of the old HTML documentation (https://brhstaging.data-commons.org/dashboard/Public/index.html)