### PR TITLE
chore(vhdc): first 6 user to scaling groups

### DIFF
--- a/va.data-commons.org/manifests/argo/argo.json
+++ b/va.data-commons.org/manifests/argo/argo.json
@@ -6,7 +6,13 @@
         "Craig.Teerlink@va.gov": "workflow4",
         "Yuk-lam.ho@va.gov": "workflow5",
         "Xin.Gong@va.gov": "workflow6",
-        "Lauren.Costa@va.gov": "workflow7"
+        "Lauren.Costa@va.gov": "workflow7",
+        "gina.peloso@va.gov": "workflow11",
+        "jon.walker4@va.gov": "workflow12",
+        "mary.rhee@va.gov": "workflow13",
+        "John.Harley3@va.gov": "workflow14",
+        "Iouri.Chepelev@va.gov": "workflow15",
+        "Dennis.Clark1@va.gov": "workflow16"
     },
     "s3-bucket": "argo-artifact-storage-downloadable",
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcprod",


### PR DESCRIPTION
Updating argo-wrapper user:scaling group mapping to include 6 new investigators.