### PR TITLE
Update gitops.json

### DIFF
--- a/brh.data-commons.org/portal/gitops.json
+++ b/brh.data-commons.org/portal/gitops.json
@@ -65,7 +65,7 @@
     "topBar": {
       "items": [
         {
-          "link": "https://uc-cdis.github.io/BRH-documentation/home/",
+          "link": "https://uc-cdis.github.io/BRH-documentation/",
           "name": "Documentation"
         }
       ]


### PR DESCRIPTION
### Description of changes
update documentation link to remove "/home" (so "https://uc-cdis.github.io/BRH-documentation/" instead of "https://uc-cdis.github.io/BRH-documentation/home" - so file name changes to home doc do not break link