### PR TITLE
Update heal prod ws image

### DIFF
--- a/healdata.org/manifests/hatchery/hatchery.json
+++ b/healdata.org/manifests/hatchery/hatchery.json
@@ -38,7 +38,7 @@
       "cpu-limit": "1.0",
       "memory-limit": "2Gi",
       "name": "(Generic) Jupyter Lab Notebook with R Kernel",
-      "image": "quay.io/cdis/jupyter-superslim-r:1.0.1",
+      "image": "quay.io/cdis/jupyter-superslim-r:markdown_preview",
       "env": {
         "FRAME_ANCESTORS": "https://healdata.org"
       },


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/jira/software/c/projects/HP/boards/85?modal=detail&selectedIssue=HP-1026&assignee=6077512a6576f4006843cc5b

### Environments
HEAL prod

### Description of changes
Aligning HEAL generic ws image with ws image in BRH - all future updates will return to 1.0.3 (x.x.x) naming schema. This workspace image is currently active in HEAL preprod and BRH prod and staging. 

In preprod we can export studies to workspaces, pip install packages, and use gen3 drs-pull to pull in study files.