### PR TITLE
Add topbar links to Cite BRH and Email Support

### DIFF
--- a/brhstaging.data-commons.org/portal/gitops.json
+++ b/brhstaging.data-commons.org/portal/gitops.json
@@ -65,8 +65,16 @@
     "topBar": {
       "items": [
         {
-          "link": "https://uc-cdis.github.io/BRH-documentation/home/",
+          "link": "https://uc-cdis.github.io/BRH-documentation/",
           "name": "Documentation"
+        }
+        {
+          "link": "mailto:brhsupport@datacommons.io",
+          "name": "Email Support"
+        }
+        {
+          "link": "https://uc-cdis.github.io/platform-citation/brh-cite/",
+          "name": "Cite BRH"
         }
       ]
     },

--- a/brhstaging.data-commons.org/portal/gitops.json
+++ b/brhstaging.data-commons.org/portal/gitops.json
@@ -67,11 +67,11 @@
         {
           "link": "https://uc-cdis.github.io/BRH-documentation/",
           "name": "Documentation"
-        }
+        },
         {
           "link": "mailto:brhsupport@datacommons.io",
           "name": "Email Support"
-        }
+        },
         {
           "link": "https://uc-cdis.github.io/platform-citation/brh-cite/",
           "name": "Cite BRH"


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://ctds-planx.atlassian.net/browse/PXP-10577
https://ctds-planx.atlassian.net/browse/BRH-367
https://ctds-planx.atlassian.net/browse/BRH-327


### Environments
BRH staging

### Description of changes
Add links to topbar for:
* Cite BRH (link to: https://uc-cdis.github.io/platform-citation/brh-cite/)(tickets for this are https://ctds-planx.atlassian.net/browse/PXP-10577 and https://ctds-planx.atlassian.net/browse/BRH-367)
* Add Email Support link to mailto:brhsupport@datacommons.io (https://ctds-planx.atlassian.net/browse/BRH-327)
* update Documentation link to remove `home/` from the end of the URL (that is now a broken link)
