### PR TITLE
fix(midrc): add submitter_id to fix portal not showing data for "imaging series"

### DIFF
--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -888,6 +888,7 @@
           "study_uid",
           "case_ids",
           "object_id",
+          "submitter_id",
           "project_id"
         ],
         "dicomViewerId": "submitter_id",

--- a/staging.midrc.org/portal/gitops.json
+++ b/staging.midrc.org/portal/gitops.json
@@ -889,6 +889,7 @@
           "study_uid",
           "case_ids",
           "object_id",
+          "submitter_id",
           "project_id"
         ],
         "dicomViewerId": "submitter_id",

--- a/validate.midrc.org/portal/gitops.json
+++ b/validate.midrc.org/portal/gitops.json
@@ -888,6 +888,7 @@
           "study_uid",
           "case_ids",
           "object_id",
+          "submitter_id",
           "project_id"
         ],
         "dicomViewerId": "submitter_id",

--- a/validatestaging.midrc.org/portal/gitops.json
+++ b/validatestaging.midrc.org/portal/gitops.json
@@ -888,6 +888,7 @@
           "study_uid",
           "case_ids",
           "object_id",
+          "submitter_id",
           "project_id"
         ],
         "dicomViewerId": "submitter_id",


### PR DESCRIPTION
Link to Jira ticket if there is one: N/A

### Environments
* data.midrc.org
* staging.midrc.org
* validate.midrc.org
* validatestaging.midrc.org

### Description of changes
* because of recent changes in 2023.02 for hiding [DICOM Viewer buttons](https://github.com/uc-cdis/data-portal/blob/5cbb45ebd7c2fd1481690dc39f07be4dc746cfe4/src/GuppyDataExplorer/ExplorerTable/index.jsx#L242), each table that has this enable should have the field in the table, in this case it [`submitter_id`](https://github.com/uc-cdis/cdis-manifest/blob/e0edcaaafe0632da24783311d3a8558fbf65128d/data.midrc.org/portal/gitops.json#L893).