### PR TITLE
Fix email support link and inactive contact site

### DIFF
--- a/brhstaging.data-commons.org/portal/gitops.json
+++ b/brhstaging.data-commons.org/portal/gitops.json
@@ -69,7 +69,7 @@
           "name": "Documentation"
         },
         {
-          "link": "mailto:brhsupport@datacommons.io",
+          "link": "brhsupport@datacommons.io",
           "name": "Email Support"
         },
         {
@@ -84,7 +84,7 @@
       "text": "The Biomedical Research Hub (BRH) is a standard-based data ecosystem for securely managing, analyzing and sharing biomedical data to support research communities and collaborations.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "contact_link": {
-        "href": "https://brh.data-commons.org/contact"
+        "href": "mailto:brhsupport@datacommons.io"
       },
       "image": "stage-icons/stage-gene"
     },


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://ctds-planx.atlassian.net/browse/BRH-327

### Environments
BRH Staging

### Description of changes
* In topbar/email support - Where it used to say "mailto:brhsupport@datacommons.io," it now says only "brhsupport@datacommons.io" because the mailto: part was unnecessary 
* In login/contact - I replaced a nonexistent Contact page link (https://brh.data-commons.org/contact) with the BRH Support email address
