### PR TITLE
argocd flag for va data commons

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -42,7 +42,6 @@
     "useryaml_s3path": "s3://cdis-gen3-users/vhdcprod/user.yaml",
     "netpolicy": "on",
     "dd_enabled": true,
-    "argocd": "true",
     "waf_enabled": "true"
   },
   "ssjdispatcher": {

--- a/va.data-commons.org/manifest.json
+++ b/va.data-commons.org/manifest.json
@@ -43,7 +43,6 @@
     "useryaml_s3path": "s3://cdis-gen3-users/vhdcprod/user.yaml",
     "netpolicy": "on",
     "dd_enabled": true,
-    "argocd": "true",
     "waf_enabled": "true"
   },
   "ssjdispatcher": {


### PR DESCRIPTION
removing argocd flag to prevent the accidental replacement of the previous prometheus installation
