### PR TITLE
Revert "role arn for buckets with no access (#5829)"

### DIFF
--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifests/fence/fence-config-public.yaml
@@ -37,7 +37,6 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000007-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000007-c2:
     cred: fence-bot
@@ -45,11 +44,9 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000179-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000179-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000200-c1:
     cred: fence-bot
@@ -60,11 +57,9 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000209-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000209-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000280-c1:
     cred: fence-bot
@@ -76,14 +71,12 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000284-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c1:
     cred: fence-bot
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000286-c3:
     cred: fence-bot
@@ -114,11 +107,9 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000784-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000820-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000914-c1:
     cred: fence-bot
@@ -357,23 +348,18 @@ S3_BUCKETS:
     region: us-east-1
   nih-nhlbi-topmed-released-phs000166-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000422-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000703-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000810-c1:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs000810-c2:
     cred: fence-bot
-    role-arn: arn:aws:iam::600168050588:role/developer_bucket_access_imaging_copdgene
     region: us-east-1
   nih-nhlbi-topmed-released-phs001012-c1:
     cred: fence-bot


### PR DESCRIPTION
This reverts commit f9d97037cf9e2bd788a9d53e0260408c21f13a28.

Link to Jira ticket if there is one:

### Environments
BDC preprod

### Description of changes
Revert role arn changes in fence config after bucket access fix from NHLBI