### PR TITLE
update niaid portal to 5.6.0

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -16,7 +16,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.04",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.04",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.04",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.04",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.6.0",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.04",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.04",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
niaid

### Description of changes
update niaid portal to 5.6.0 to fix clickjacking vulnerability 