### PR TITLE
Remove links to non-HHS sites

### DIFF
--- a/nci-crdc-staging.datacommons.io/portal/gitops.json
+++ b/nci-crdc-staging.datacommons.io/portal/gitops.json
@@ -76,10 +76,6 @@
           "icon": "upload",
           "link": "/submission",
           "name": "Submit Data"
-        },
-        {
-          "link": "https://gen3.org/resources/user/",
-          "name": "Documentation"
         }
       ]
     },
@@ -137,12 +133,10 @@
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",
-        "href": "https://ctds.uchicago.edu/gen3",
         "alt": "Gen3 Data Commons"
       },
       {
         "src": "/src/img/createdby.png",
-        "href": "https://ctds.uchicago.edu/",
         "alt": "Center for Translational Data Science at the University of Chicago"
       }
     ],


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
nci-crdc-staging.datacommons.io

### Description of changes
Remove links to non-HHS websites