### PR TITLE
Remove charts from vpodc

### DIFF
--- a/vpodc.data-commons.org/portal/gitops.json
+++ b/vpodc.data-commons.org/portal/gitops.json
@@ -167,24 +167,7 @@
   "explorerConfig": [
     {
       "tabTitle": "Patients",
-      "charts": {
-        "Chicago_ID": {
-          "chartType": "count",
-          "title": "Patients"
-        },
-        "Oncology_Primary.ICDOSite": {
-          "chartType": "bar",
-          "title": "Site (ICD-O)"
-        },
-        "Oncology_Primary.Radiation": {
-          "chartType": "pie",
-          "title": "Radiation"
-        },
-        "Oncology_Primary.Chemotherapy": {
-          "chartType": "pie",
-          "title": "Chemotherapy"
-        }
-      },
+      "charts": {},
       "filters": {
         "tabs": [
           {


### PR DESCRIPTION
Charts slow down the explorer page, removing to increase performance.

Link to Jira ticket if there is one:

### Environments
https://vpodc.data-commons.org

### Description of changes
- Removed charts from explorer page as they were slowing down the whole page for minutes on each load. 