### PR TITLE
Align table displays in gitops.json

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/portal/gitops.json
+++ b/accessclinicaldata.niaid.nih.gov/portal/gitops.json
@@ -88,7 +88,7 @@
       "rowAccessor": "cmc_unique_id",
       "listItemConfig": {
         "blockFields": ["brief_summary"],
-        "tableFields": ["data_availability_date", "most_recent_update", "previous_versions", "data_available", "creator", "nct_number", "condition", "category", "clinical_trial_website", "publications","study_registration","study_registration_id"],
+        "tableFields": ["data_availability_date", "most_recent_update", "previous_versions", "data_available", "creator", "nct_number", "condition", "category", "study_design_primary_purpose", "study_design_allocation", "study_start_date", "study_completion_date", "clinical_trial_website", "publications","study_registration","study_registration_id"],
         "hideEmptyFields": true
       },
       "singleItemConfig": {


### PR DESCRIPTION
Update gitops.json for NIAID PROD to display the same table contents in both the Summary and Detailed views in the Study Viewer.

Link to Jira ticket if there is one:

### Environments
NIAID Prod (accessclinicaldata.niaid.nih.gov)

### Description of changes
Update gitops.json for NIAID PROD to display the same table contents in both the Summary and Detailed views in the Study Viewer.