### PR TITLE
update IBD portal to 5.11.1

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7613,7 +7613,7 @@
         "filename": "ibdgc.datacommons.io/manifest.json",
         "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 125
       }
     ],
     "internalstaging.theanvil.io/manifest.json": [
@@ -9166,5 +9166,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-01T18:08:08Z"
+  "generated_at": "2023-08-11T20:15:00Z"
 }

--- a/ibdgc.datacommons.io/manifest.json
+++ b/ibdgc.datacommons.io/manifest.json
@@ -13,7 +13,7 @@
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:3.2.1",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.8.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.11.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.05",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.7.5",

--- a/ibdgc.datacommons.io/manifest.json
+++ b/ibdgc.datacommons.io/manifest.json
@@ -13,7 +13,7 @@
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:3.2.1",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.11.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.11.1",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.05",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.7.5",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
IBD

### Description of changes
- add more options to Discovery page isAuthorized check ([#1380](https://github.com/uc-cdis/data-portal/pull/1380)) 
- Discovery page update tooltip text ([#1382](https://github.com/uc-cdis/data-portal/pull/1382)) 
- Discovery page: remove empty “Tags by category” component ([#1381](https://github.com/uc-cdis/data-portal/pull/1381)) 
- study descriptions render html tags for br, strong, table, tr, td, th ([#1369](https://github.com/uc-cdis/data-portal/pull/1369))
- lots of Dependency Updates see data portal 5.11.0 release for full list 
- GWAS Results app: Run Duration shows correct duration instead of “Invalid date” in Execution view ([#1378](https://github.com/uc-cdis/data-portal/pull/1378)) 
- This resolves odd UI behavior that was the result of the incorrectly implemented initialTableSort function. ([#1377](https://github.com/uc-cdis/data-portal/pull/1377)) 
- This version ensures that disabling of workspace launch button when no pay model is selected, happens only for commons with pay models enabled. ([#1374](https://github.com/uc-cdis/data-portal/pull/1374)) 
- This updates the results App so that back button is hidden when not on home view, and shown on the app's home view. ([#1377](https://github.com/uc-cdis/data-portal/pull/1377)) 
- New features and some bug fixes for VADC GWAS apps, including multiple improvements to the GWAS Results Viewer (see details [here](https://github.com/uc-cdis/data-portal/pull/1372#issuecomment-1660269113)) ([#1372](https://github.com/uc-cdis/data-portal/pull/1372))
- Unit test written to validate initialTableSort function. ([#1377](https://github.com/uc-cdis/data-portal/pull/1377)) 
-  Pay model resets as soon as a workspace session is terminated ([#1374](https://github.com/uc-cdis/data-portal/pull/1374)) 
- Workspace launch is restricted when current paymodel is not set for commons where pay models are available. ([#1374](https://github.com/uc-cdis/data-portal/pull/1374)) 
- Added `d3-axis, d3-format, d3-tip` ([#1372](https://github.com/uc-cdis/data-portal/pull/1372)) 
- Updates to Study Registration / VLMD Submission page to support nested fields (#1365)
- update clinicaltrials.gov api to classic endpoint (#1365)
- Disocvery page: study details fields, discovery table fields, aggregation fields and search fields now supports using [JSONPath 
  syntax](https://github.com/dchester/jsonpath#jsonpath-syntax) to represent nested fields in metadata (#1324)
- Replace the Dropdown text with `Select a Pay model` when there is no current_pay_model available. (#1368)
- Prevent `getWorkspacePayModel` from returning null when there is no current_pay_model (#1368)
- When there is no current_pay_model available, disable the `Launch` button (#1368)
- Add an `Alert message` asking the user to choose a pay model (#1368)
- Adds: "jsonpath": "^1.1.1", (#1324)