### PR TITLE
Map Canine Study Name same path as Full Name to get rid of N/A (DO NOT MERGE UNTIL PROBLEM SOLVE, see below for more detail)

### DIFF
--- a/brh.data-commons.org/metadata/aggregate_config.json
+++ b/brh.data-commons.org/metadata/aggregate_config.json
@@ -271,7 +271,7 @@
 				"study_id": "path:clinical_study_designation",
 				"study_description": "",
 				"full_name": "path:clinical_study_name",
-				"short_name": "N/A",
+				"short_name": "path:clinical_study_name",
 				"commons": "CRDC Integrated Canine Data Commons",
 				"study_url": "N/A",
 				"_subjects_count" : {"path":"numberOfCases", "default" : 0 },			


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://ctds-planx.atlassian.net/browse/BRH-648?atlOrigin=eyJpIjoiN2I4NTE2N2Q2MjhlNDVmOWIxODg0ZDhkYzE0YjY5NmQiLCJwIjoiaiJ9

### Environments

### Description of changes
!!! DO NOT MERGE UNTIL PROBLEM IS FIXED AND CANINE NAME IS SHOWING UP IN BRH-STAGING!!!

When running QA-BRH, error came across agg-MDS-sync with GDC and AnVIL, which the sync run stops at the error and doesn't continue to run the rest of the Data Commons. We think it might be the same problem in BRH-Staging, hence, waiting on more info.