### PR TITLE
adding fix for missing pelican-export ECR image

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6929,21 +6929,21 @@
         "filename": "gen3.theanvil.io/manifest.json",
         "hashed_secret": "0447a636536df0264b2000403fbefd69f603ceb1",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": "gen3.theanvil.io/manifest.json",
         "hashed_secret": "ca253d1c9dece2da0d6fb24ded7bdb849a475966",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 119
       },
       {
         "type": "Secret Keyword",
         "filename": "gen3.theanvil.io/manifest.json",
         "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
         "is_verified": false,
-        "line_number": 225
+        "line_number": 224
       }
     ],
     "healdata.org/dashboard/Public/notebooks/JCOIN-MOUD_accessibility_analysis_02092022.html": [
@@ -9166,5 +9166,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-01T18:08:08Z"
+  "generated_at": "2023-08-15T16:59:34Z"
 }

--- a/gen3.theanvil.io/manifest.json
+++ b/gen3.theanvil.io/manifest.json
@@ -59,7 +59,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.06",
+        "image": "quay.io/cdis/pelican-export:2023.06",
         "pull_policy": "Always",
         "env": [
           {
@@ -127,7 +127,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.06",
+        "image": "quay.io/cdis/pelican-export:2023.06",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
### Environments
gen3.theanvil.io

### Description of changes
update pelican export to use quay rather than ECR as 2023.06 is missing from ECR repo.