### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,20 +38,20 @@ gen3qa.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 gen3staging.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 data.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 
-ibdgc.datacommons.io @hughestr @uc-cdis/planx-qa
-jcoin.datacommons.io @hughestr @uc-cdis/planx-qa
-accessclinicaldata.niaid.nih.gov @hughestr @uc-cdis/planx-qa
+ibdgc.datacommons.io @trevars @uc-cdis/planx-qa
+jcoin.datacommons.io @trevars @uc-cdis/planx-qa
+accessclinicaldata.niaid.nih.gov @trevars @uc-cdis/planx-qa
 
-chicagoland.pandemicresponsecommons.org @hughestr @michaelfitzo @uc-cdis/planx-qa
+chicagoland.pandemicresponsecommons.org @michaelfitzo @uc-cdis/planx-qa
 
 gen3.datacommons.io @trevars @cgmeyer @uc-cdis/planx-qa
 
 portal.occ-data.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ
 data.bloodpac.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ
 
-healdata.org @hughestr @uc-cdis/planx-qa
-preprod.healdata.org @hughestr @uc-cdis/planx-qa
-externaldata.healdata.org @hughestr @uc-cdis/planx-qa
+healdata.org @briennal @uc-cdis/planx-qa
+preprod.healdata.org @briennal @uc-cdis/planx-qa
+externaldata.healdata.org @briennal @uc-cdis/planx-qa
 
 brh.data-commons.org @briennal @uc-cdis/planx-qa
 brhstaging.data-commons.org @briennal @uc-cdis/planx-qa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,18 @@
-acct.bionimbus.org @trevars @uc-cdis/planx-qa
-caninedc.org @trevars @uc-cdis/planx-qa
-dataguids.org @trevars @uc-cdis/planx-qa
-genomel.bionimbus.org @trevars @uc-cdis/planx-qa
-internal-icgc.bionimbus.org @trevars @uc-cdis/planx-qa
-icgc.bionimbus.org @trevars @uc-cdis/planx-qa
-aids.diseasedatahub.org @trevars @uc-cdis/planx-qa
-tb.diseasedatahub.org @trevars @uc-cdis/planx-qa
-flu.diseasedatahub.org @trevars @uc-cdis/planx-qa
-diseasedatahub.org @trevars @uc-cdis/planx-qa
-dcf-interop.kidsfirstdrc.org @trevars @uc-cdis/planx-qa
-chorus.data-commons.org @trevars @uc-cdis/planx-qa
+acct.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
+caninedc.org @trevars @beamcb @uc-cdis/planx-qa
+dataguids.org @trevars @beamcb @uc-cdis/planx-qa
+genomel.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
+internal-icgc.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
+icgc.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
+aids.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
+tb.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
+flu.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
+diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
+dcf-interop.kidsfirstdrc.org @trevars @beamcb @uc-cdis/planx-qa
+chorus.data-commons.org @trevars @beamcb @uc-cdis/planx-qa
 
 nci-crdc-staging.datacommons.io @frankliuao @uc-cdis/planx-qa
 nci-crdc.datacommons.io @frankliuao @uc-cdis/planx-qa
-
-tbi.datacommons.io @trevars @uc-cdis/planx-qa
-gen3-neuro.datacommons.io @trevars @uc-cdis/planx-qa
 
 va-testing.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
 va.data-commons.org @nmetokishlubsky @uc-cdis/planx-qa
@@ -38,13 +35,14 @@ gen3qa.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 gen3staging.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 data.kidsfirstdrc.org @radhrreddy @uc-cdis/planx-qa
 
-ibdgc.datacommons.io @trevars @uc-cdis/planx-qa
-jcoin.datacommons.io @trevars @uc-cdis/planx-qa
-accessclinicaldata.niaid.nih.gov @trevars @uc-cdis/planx-qa
+ibdgc.datacommons.io @trevars @beamcb @uc-cdis/planx-qa
+jcoin.datacommons.io @trevars @beamcb @uc-cdis/planx-qa
+accessclinicaldata.niaid.nih.gov @trevars @beamcb @uc-cdis/planx-qa
 
-chicagoland.pandemicresponsecommons.org @michaelfitzo @uc-cdis/planx-qa
+chicagoland.pandemicresponsecommons.org @michaelfitzo @beamcb @uc-cdis/planx-qa
+elwazi-demo.planx-pla.net @michaelfitzo @beamcb @uc-cdis/planx-qa
 
-gen3.datacommons.io @trevars @cgmeyer @uc-cdis/planx-qa
+gen3.datacommons.io @trevars @beamcb @cgmeyer @uc-cdis/planx-qa
 
 portal.occ-data.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ
 data.bloodpac.org @Mikisha10 @uc-cdis/planx-qa @urvi-occ


### PR DESCRIPTION
Replacing hughestr

Link to Jira ticket if there is one:

### Environments
ibdgc.datacommons.io 
jcoin.datacommons.io 
accessclinicaldata.niaid.nih.gov 

elwazi-demo.planx-pla.net
gen3-neuro.datacommons.io
tbi-datacommons.io

chicagoland.pandemicresponsecommons.org

healdata.org
preprod.healdata.org
externaldata.healdata.org

### Description of changes
Removed user @hughestr.
Added @beamcb.
Added @trevars.

Added elwazi-demo.planx-pla.net
Removed gen3-neuro.datacommons.io & tbi-datacommons.io
