### PR TITLE
updating global dictionary url to latest release 4.4.3

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -207,7 +207,7 @@
     "environment": "stageprod",
     "hostname": "gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/472403d1-09a8-4d10-a5de-9b316f7da980",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.3/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",

--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -207,7 +207,7 @@
     "environment": "stageprod",
     "hostname": "gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/472403d1-09a8-4d10-a5de-9b316f7da980",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.3/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.2/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",

--- a/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -401,7 +401,7 @@
     "environment": "stageprod",
     "hostname": "preprod.gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/a82bb5ed-9ad1-444d-9bfd-5bc314541307",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.3/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",

--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -291,7 +291,7 @@
     "environment": "stagingdatastage",
     "hostname": "staging.gen3.biodatacatalyst.nhlbi.nih.gov",
     "revproxy_arn": "arn:aws:acm:us-east-1:895962626746:certificate/1876fa51-031e-4aa9-ab95-7da182a52c7f",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.2/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/4.4.3/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments


### Description of changes
