### PR TITLE
fix(manifest-formatting): Updatd manifest formatting to remove syntax…

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -48,7 +48,7 @@
     "public_datasets": true,
     "dispatcher_job_num": "10",
     "maintenance_mode": "off",
-    "pdb": "on",
+    "pdb": "on"
   },
   "ssjdispatcher": {
     "job_images": {

--- a/externaldata.healdata.org/manifest.json
+++ b/externaldata.healdata.org/manifest.json
@@ -37,7 +37,7 @@
     "netpolicy": "on",
     "tier_access_level": "libre",
     "useryaml_s3path": "s3://cdis-gen3-users/heal/user.yaml",
-    "pdb": "on",
+    "pdb": "on"
   },
   "canary": {
     "default": 0

--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -220,7 +220,7 @@
     "netpolicy": "on",
     "argocd": "true",
     "pdb": "on",
-    "waf_enabled": "true",
+    "waf_enabled": "true"
   },
   "canary": {
     "default": 0

--- a/gen3.theanvil.io/manifest.json
+++ b/gen3.theanvil.io/manifest.json
@@ -47,7 +47,7 @@
     "tier_access_limit": 50,
     "public_datasets": true,
     "argocd": "true",
-    "waf_enabled": "true",
+    "waf_enabled": "true"
   },
   "peregrine": {
     "peregrine_timeout": "45"

--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -304,7 +304,7 @@
     "netpolicy": "on",
     "argocd": "true",
     "waf_enabled": "true",
-    "pdb": "on",
+    "pdb": "on"
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
### Environments
All

### Description of changes
removed extra comma's from broken manifests