### PR TITLE
feat(midrc): going back to quay images for ohif-viewer

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -17,7 +17,7 @@
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.09",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.09",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.09",
-    "ohif-viewer": "docker.io/ohif/app:v3.7.0-beta.85",
+    "ohif-viewer": "quay.io/cdis/ohif-viewer:master",
     "orthanc": "docker.io/osimis/orthanc:master",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.09",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.13.0",


### PR DESCRIPTION
Link to Jira ticket if there is one: N/A

### Environments
* staging.midrc.org

### Description of changes
* going back to quay served images, upstream Docker images are not readily available