### PR TITLE
MIDRC staging: pin OHIF viewer

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -18,7 +18,7 @@
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.11",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.11",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.11",
-    "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:master-gen3",
+    "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-v3.7.0-beta.99",
     "orthanc": "docker.io/osimis/orthanc:master",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.11",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.11",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
MIDRC staging

### Description of changes
The `gen3-v3.7.0-beta.99` tag should be identical to the current `master-gen3` tag. This is not an update, we just need to pin to a tag other than master.
https://github.com/uc-cdis/Viewers/releases/tag/gen3-v3.7.0-beta.99