### PR TITLE
MIDRC prod: pin OHIF viewer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6893,7 +6893,7 @@
         "filename": "data.midrc.org/manifest.json",
         "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 85
       }
     ],
     "elwazi-demo.planx-pla.net/dashboard/Secure/reports/modules/jasmine-core/package.json": [
@@ -9624,5 +9624,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-06T19:57:38Z"
+  "generated_at": "2023-11-20T21:26:29Z"
 }

--- a/data.midrc.org/manifest.json
+++ b/data.midrc.org/manifest.json
@@ -18,7 +18,7 @@
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.10",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.10",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.10",
-    "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:master-gen3",
+    "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-v3.7.0-beta.99",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.10",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.16.0",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.10",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
MIDRC prod

### Description of changes
The `gen3-v3.7.0-beta.99` tag should be identical to the current `master-gen3` tag. This is not an update, we just need to pin to a tag other than master.
https://github.com/uc-cdis/Viewers/releases/tag/gen3-v3.7.0-beta.99