### PR TITLE
ACCOuNT prefix

### DIFF
--- a/dataguids.org/manifest.json
+++ b/dataguids.org/manifest.json
@@ -232,6 +232,14 @@
           ".*dg\\.OADC.*"
         ],
         "type": "indexd"
+      },
+      {
+        "name": "ACCOuNT",
+        "host": "https://gen3.datacommons.io/index/",
+        "hints": [
+          ".*dg\\.4825.*"
+        ],
+        "type": "indexd"
       }
     ]
   }


### PR DESCRIPTION
### Environments
dataguids.org

### Description of changes
added account prefix and make it point to gen3.datacommoms.org as all necessary data has been relocated to there.