### PR TITLE
Update manifest.json

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -22,7 +22,7 @@
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/ohdsi/atlas:2.13.0",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/ohdsi/webapi:2.13.0",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.11",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.17.1",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:feat_login",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.11",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.11",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.11",

--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -90,7 +90,8 @@
   "featureFlags": {
     "explorer": false,
     "analysis": true,
-    "workspaceTokenServiceRefreshTokenAtLogin": true
+    "workspaceTokenServiceRefreshTokenAtLogin": true,
+    "forceSingleLoginDropdownOptions": ["InCommon Login"]
   },
   "analysisTools": [
     {


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
* va-testing.data-commons.org

### Description of changes
* because we can't deploy `master` branch, deploying branch with cherry-picked changes on top of [5.17.1](https://github.com/uc-cdis/data-portal/releases/tag/5.17.1) (so this new release is impossible to use [5.18.2](https://github.com/uc-cdis/data-portal/releases/tag/5.18.2)) with showing dropdown when only single login option present