### PR TITLE
Updating diseasedatahub to release 2023.12 in preparation for ES7 changes

### DIFF
--- a/diseasedatahub.org/manifest.json
+++ b/diseasedatahub.org/manifest.json
@@ -5,23 +5,22 @@
   ],
   "versions": {
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "arborist": "quay.io/cdis/arborist:2.3.0",
-    "fence": "quay.io/cdis/fence:4.10.0",
-    "indexd": "quay.io/cdis/indexd:2.1.0",
-    "portal": "quay.io/cdis/data-ecosystem-portal:1.2.4",
-    "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
+    "arborist": "quay.io/cdis/arborist:2023.12",
+    "fence": "quay.io/cdis/fence:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "portal": "quay.io/cdis/data-ecosystem-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "spark": "quay.io/cdis/gen3-spark:1.0.0",
-    "wts": "quay.io/cdis/workspace-token-service:0.2.0",
-    "manifestservice": "quay.io/cdis/manifestservice:0.2.0",
-    "tube": "quay.io/cdis/tube:0.3.15",
-    "hatchery": "quay.io/cdis/hatchery:0.1.1",
-    "ambassador": "quay.io/datawire/ambassador:0.60.3",
-    "guppy": "quay.io/cdis/guppy:0.3.7",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.12",
-    "peregrine": "quay.io/cdis/peregrine:1.2.1",
-    "pidgin": "quay.io/cdis/pidgin:1.1.0"
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "hatchery": "quay.io/cdis/hatchery:2023.12",
+    "ambassador": "quay.io/datawire/ambassador:1.4.2",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12"
   },
   "global": {
     "environment": "niaiddata",
@@ -39,7 +38,8 @@
     "cookie_domain": "diseasedatahub.org",
     "public_datasets": true,
     "pdb": "on",
-    "tier_access_level": "libre"
+    "tier_access_level": "libre",
+    "es7": true
   },
   "hatchery": {
     "user-namespace": "jupyter-pods-niaiddata",

--- a/diseasedatahub.org/manifest.json
+++ b/diseasedatahub.org/manifest.json
@@ -34,7 +34,7 @@
     "dispatcher_job_num": "10",
     "useryaml_s3path": "s3://cdis-gen3-users/nde/user.yaml",
     "origins_allow_credentials": ["https://tb.diseasedatahub.org", "https://aids.diseasedatahub.org", "https://microbiome.diseasedatahub.org", "https://flu.diseasedatahub.org"],
-    "netpolicy": "off",
+    "netpolicy": "on",
     "cookie_domain": "diseasedatahub.org",
     "public_datasets": true,
     "pdb": "on",


### PR DESCRIPTION
### Environments
diseasedatahub

### Description of changes
diseasedatahub is scheduled to be switched to a new ES7 cluster soon so we need to update the images to the latest release. DO NOT MERGE without speaking with PE first.