### PR TITLE
Replace fence 2023.12 with semver

### DIFF
--- a/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/staging.gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -12,7 +12,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.12",
     "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:9.1.4",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:9.3.3",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.12",


### PR DESCRIPTION
Fence 9.3.3 contained fixes that were not in the december release that are needed by our downstream users.

Link to Jira ticket if there is one:

### Environments
- BDC Staging

### Description of changes
