### PR TITLE
Add data_file_annotation_name to gitops.json and etlMapping in Prod 

### DIFF
--- a/data.midrc.org/etlMapping.yaml
+++ b/data.midrc.org/etlMapping.yaml
@@ -205,6 +205,15 @@ mappings:
           - name: data_category
             src: data_category
             fn: set
+          - name: data_file_source_node
+            src: source_node
+            fn: set
+          - name: data_file_annotation_name
+            src: annotation_name
+            fn: set
+          - name: data_file_annotation_method
+            src: annotation_method
+            fn: set
   - name: midrc_data_file
     doc_type: data_file
     type: collector

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -1009,11 +1009,10 @@
           {
             "title": "Annotations",
             "fields": [
-              "imaging_study_annotations.airspace_disease_grading",
-              "imaging_study_annotations.class_covid19_pneumonia",
               "imaging_study_annotations.midrc_mRALE_score",
               "imaging_study_annotations.annotation_method",
-              "imaging_study_annotations.annotator_id"
+              "imaging_study_annotations.annotator_id",
+              "data_file_annotation_name"
             ]
           }
         ]
@@ -1044,12 +1043,11 @@
           "race",
           "ethnicity",
           "zip",
-          "imaging_study_annotations.airspace_disease_grading",
-          "imaging_study_annotations.class_covid19_pneumonia",
           "imaging_study_annotations.midrc_mRALE_score",
           "imaging_study_annotations.annotation_method",
           "imaging_study_annotations.annotator_id",
           "imaging_study_annotations.instance_uids",
+          "data_file_annotation_name",
           "_ct_series_file_count",
           "_dx_series_file_count",
           "_cr_series_file_count",


### PR DESCRIPTION
Link to Jira ticket if there is one: [MIDRC-583](https://ctds-planx.atlassian.net/browse/MIDRC-583)

### Environments
- [data.midrc.org](data.midrc.org)

### Description of changes
- Added `data_file_source_node`, `data_file_annotation_name`, and `data_file_annotation_method` to etlMapping
- Added `data_file_annotation_name` to the Imaging Study Tab's Annotation filters
- Added `data_file_annotation_name` to the Imaging Study Tab's table
- Removed `airspace_disease_grading` and `class_covid19_pneumonia` from Imaging Study Tab's Annotation filters
- Removed `airspace_disease_grading` and `class_covid19_pneumonia` from Imaging Study Tab's table


[MIDRC-583]: https://ctds-planx.atlassian.net/browse/MIDRC-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ