### PR TITLE
Fix: add arborist_url to global config section of VA test

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -40,6 +40,7 @@
     "dispatcher_job_num": "10",
     "useryaml_s3path": "s3://cdis-gen3-users/va-testing/user.yaml",
     "netpolicy": "on",
+    "arborist_url": "http://arborist-service",
     "pdb": "on",
     "waf_enabled": "true"
   },


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-963

### Environments
- VA test

### Description of changes
- Fix: add arborist_url to global config section of VA test