### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,13 @@
-acct.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
+acct.bionimbus.org @uc-cdis/planx-qa
 caninedc.org @trevars @beamcb @uc-cdis/planx-qa
 dataguids.org @trevars @beamcb @uc-cdis/planx-qa
 genomel.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
-internal-icgc.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
 icgc.bionimbus.org @trevars @beamcb @uc-cdis/planx-qa
-aids.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
-tb.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
-flu.diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
-diseasedatahub.org @trevars @beamcb @uc-cdis/planx-qa
+aids.diseasedatahub.org @uc-cdis/planx-qa
+tb.diseasedatahub.org @uc-cdis/planx-qa
+flu.diseasedatahub.org  @uc-cdis/planx-qa
+diseasedatahub.org @uc-cdis/planx-qa
 dcf-interop.kidsfirstdrc.org @trevars @beamcb @uc-cdis/planx-qa
-chorus.data-commons.org @trevars @beamcb @uc-cdis/planx-qa
 
 nci-crdc-staging.datacommons.io @CTDS-Fortel @uc-cdis/planx-qa
 nci-crdc.datacommons.io @CTDS-Fortel @uc-cdis/planx-qa
@@ -40,7 +38,7 @@ jcoin.datacommons.io @trevars @beamcb @uc-cdis/planx-qa
 accessclinicaldata.niaid.nih.gov @frankliuao @beamcb @uc-cdis/planx-qa
 
 chicagoland.pandemicresponsecommons.org @michaelfitzo @beamcb @uc-cdis/planx-qa
-elwazi-demo.planx-pla.net @michaelfitzo @beamcb @uc-cdis/planx-qa
+elwazi-demo.planx-pla.net @michaelfitzo @uc-cdis/planx-qa
 
 gen3.datacommons.io @trevars @beamcb @cgmeyer @uc-cdis/planx-qa
 


### PR DESCRIPTION
Removing owners from instances that are out of scope or not running

### Environments
acct.bionimbus.org
internal-icgc.bionimbus.org
aids.diseasedatahub.org
tb.diseasedatahub.org
flu.diseasedatahub.org
diseasedatahub.org
chorus.data-commons.org
elwazi-demo.planx-pla.net

### Description of changes
acct.bionimbus.org - removed owner, not up & running
internal-icgc.bionimbus.org - removed entirely, doesn't exist
aids.diseasedatahub.org - removed owner, out of scope
tb.diseasedatahub.org - removed owner, out of scope
flu.diseasedatahub.org - removed owner, out of scope
diseasedatahub.org - removed owner, out of scope
chorus.data-commons.org - removed entirely, doesn't exist
elwazi-demo.planx-pla.net - removed owner, not up & running
