### PR TITLE
VADC-912: Updated buckets' names

### DIFF
--- a/healdata.org/manifests/argo/argo.json
+++ b/healdata.org/manifests/argo/argo.json
@@ -2,7 +2,7 @@
     "scaling_groups" : {
         "Devops testing": "workflow"},
     "internal-s3-bucket": "gen3-argo-205252583234-healprod",
-    "s3-bucket": "argo-artifact-storage-downloadable-healprod",
+    "downloadable-s3-bucket": "argo-artifact-storage-downloadable-healprod",
     "indexd_admin_user": "fence",
     "environment": "default",
     "pvc": "parallel-test-pvc"

--- a/preprod.healdata.org/manifests/argo/argo.json
+++ b/preprod.healdata.org/manifests/argo/argo.json
@@ -2,7 +2,7 @@
     "scaling_groups" : {
         "Devops testing": "workflow"},
     "internal-s3-bucket": "gen3-argo-205252583234-healprod",
-    "s3-bucket": "argo-artifact-storage-downloadable-healprod",
+    "downloadable-s3-bucket": "argo-artifact-storage-downloadable-healprod",
     "indexd_admin_user": "fence",
     "environment": "healpreprod",
     "pvc": "parallel-test-pvc"

--- a/va-perf.data-commons.org/manifests/argo/argo.json
+++ b/va-perf.data-commons.org/manifests/argo/argo.json
@@ -8,7 +8,7 @@
         "Xin.Gong@va.gov": "workflow6",
         "Lauren.Costa@va.gov": "workflow7"
     },
-    "s3-bucket": "argo-artifact-storage-downloadable-va-perf",
+    "downloadable-s3-bucket": "argo-artifact-storage-downloadable-va-perf",
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcperf",
     "indexd_admin_user": "fence",
     "environment": "default",

--- a/va-perf.data-commons.org/manifests/argo/argo.json
+++ b/va-perf.data-commons.org/manifests/argo/argo.json
@@ -12,5 +12,6 @@
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcperf",
     "indexd_admin_user": "fence",
     "environment": "default",
-    "pvc": "parallel-test-pvc"
+    "pvc": "parallel-test-pvc",
+    "argo_namespace": "argo"
 }

--- a/va-testing.data-commons.org/manifests/argo/argo.json
+++ b/va-testing.data-commons.org/manifests/argo/argo.json
@@ -7,7 +7,7 @@
             "Craig.Teerlink@va.gov": "{{workflow.name}}"
         }
     },
-    "s3-bucket": "argo-artifact-storage-downloadable-va-testing-2024",
+    "downloadable-s3-bucket": "argo-artifact-storage-downloadable-va-testing-2024",
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcprod",
     "indexd_admin_user": "fence",
     "environment": "va-testing",

--- a/va-testing.data-commons.org/manifests/argo/argo.json
+++ b/va-testing.data-commons.org/manifests/argo/argo.json
@@ -11,5 +11,6 @@
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcprod",
     "indexd_admin_user": "fence",
     "environment": "va-testing",
-    "pvc": "parallel-test-pvc"
+    "pvc": "parallel-test-pvc",
+    "argo_namespace": "argo-va-testing"
 }

--- a/va.data-commons.org/manifests/argo/argo.json
+++ b/va.data-commons.org/manifests/argo/argo.json
@@ -48,5 +48,6 @@
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcprod",
     "indexd_admin_user": "fence",
     "environment": "default",
-    "pvc": "parallel-test-pvc"
+    "pvc": "parallel-test-pvc",
+    "argo_namespace": "argo"
 }

--- a/va.data-commons.org/manifests/argo/argo.json
+++ b/va.data-commons.org/manifests/argo/argo.json
@@ -44,7 +44,7 @@
             "aartiv@uchicago.edu": "{{workflow.name}}"
         }
     },
-    "s3-bucket": "argo-artifact-storage-downloadable-2024",
+    "downloadable-s3-bucket": "argo-artifact-storage-downloadable-2024",
     "internal-s3-bucket": "gen3-argo-199578515826-vhdcprod",
     "indexd_admin_user": "fence",
     "environment": "default",


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-912](https://ctds-planx.atlassian.net/browse/VADC-912)

### Environments
* va-perf.data-commons.org
* va-testing.data-commons.org
* va.data-commons.org
* healdata.org
* preprod.healdata.org

### Description of changes
* Updated buckets' names


[VADC-912]: https://ctds-planx.atlassian.net/browse/VADC-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ