### PR TITLE
VADC-912: Change template version to use configurable buckets

### DIFF
--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -1,6 +1,6 @@
 {
   "gaTrackingId": "G-ENMRJKCVSY",
-  "argoTemplate": "gwas-template-new-bucket-va-testing",
+  "argoTemplate": "gwas-template-configurable-buckets",
   "graphql": {
     "boardCounts": [],
     "chartCounts": [],


### PR DESCRIPTION

Link to Jira ticket if there is one: [VADC-912](https://ctds-planx.atlassian.net/browse/VADC-912)

### Environments
* va-testing.data-commons.org


### Description of changes
* Updated template version