### PR TITLE
VADC-912: Change template version to use configurable buckets

### DIFF
--- a/va.data-commons.org/portal/gitops.json
+++ b/va.data-commons.org/portal/gitops.json
@@ -1,6 +1,6 @@
 {
   "gaTrackingId": "G-MNK00L5EG7",
-  "argoTemplate": "gwas-template-new-bucket",
+  "argoTemplate": "gwas-template-configurable-buckets",
   "graphql": {
     "boardCounts": [],
     "chartCounts": [],


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-912](https://ctds-planx.atlassian.net/browse/VADC-912)

### Environments
* va.data-commons.org

### Description of changes
* Updated template version


[VADC-912]: https://ctds-planx.atlassian.net/browse/VADC-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ