### PR TITLE
updating pelican-export image

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -52,7 +52,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:1.0.1",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2024.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -116,7 +116,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:1.0.1",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2024.02",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
Link to Jira ticket if there is one:
GPE-1138

### Environments
BDCAT Prod

### Description of changes
updating the pelican export image so we can set a lifecycle policy to remove old images on the pelican-export ECR repo. 