### PR TITLE
v1.3.2: Updates to annotation properties

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -164,7 +164,7 @@
     "kube_bucket": "kube-midrcprod-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcprod-gen3",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.0/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.2/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
Updates to the MIDRC data dictionary can be found on the MIDRC GitHub [here](https://github.com/uc-cdis/midrc_dictionary/pull/137) and on the MIDRC confluence voting page [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1625784321/Data+Model+Release+1.3.2+Ready+for+votes).
