### PR TITLE
Update MIDRC ValidateStaging DD 1.3.2

### DIFF
--- a/validatestaging.midrc.org/manifest.json
+++ b/validatestaging.midrc.org/manifest.json
@@ -160,7 +160,7 @@
     "kube_bucket": "kube-midrcvalidate-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcvalidate-gen3",
-    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.0/schema.json",
+    "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.2/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- validatestaging.midrc.org

### Description of changes
All changes for the 1.3.2 MIDRC DD release can be found [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1625784321/Data+Model+Release+1.3.2+Ready+for+votes).

- Update enum for the annotation_name property in the following files: annotation_file, dicom_annotation_file, and annotation.
     - annotation_name enum value for mRALE annotations: change to "midrc_mRALE_Mastermind_Challenge" from "mRALE_Mastermind_Challenge".
- Update the data_type property description and enums in the annotation_file and the dicome_annotation_file.
     - data_type property description: “An indication of whether the annotation is expert validated by MIDRC (“Internal Annotation”) or has not be validated by MIDRC experts (“External Annotation”).
     - data_type enum values: “Internal Annotation” and “External Annotation”.