### PR TITLE
VADC-1087: Auto self-destruct GWAS workflow after 8 hours

### DIFF
--- a/va.data-commons.org/portal/gitops.json
+++ b/va.data-commons.org/portal/gitops.json
@@ -1,6 +1,6 @@
 {
   "gaTrackingId": "G-MNK00L5EG7",
-  "argoTemplate": "gwas-template-fix-timeout",
+  "argoTemplate": "gwas-template-deadline",
   "graphql": {
     "boardCounts": [],
     "chartCounts": [],


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-1087](https://ctds-planx.atlassian.net/browse/VADC-1087)

### Environments
* va.data-commons.org


### Description of changes
* Updated Argo template to auto self-destruct GWAS workflow after 8 hours

[VADC-1087]: https://ctds-planx.atlassian.net/browse/VADC-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ