### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@ gen3staging.kidsfirstdrc.org @CTDS-Fortel @uc-cdis/planx-qa
 data.kidsfirstdrc.org @CTDS-Fortel @uc-cdis/planx-qa
 
 jcoin.datacommons.io @trevars @beamcb @uc-cdis/planx-qa
-accessclinicaldata.niaid.nih.gov @frankliuao @beamcb @uc-cdis/planx-qa
+accessclinicaldata.niaid.nih.gov @frankliuao @uc-cdis/planx-qa
 
 chicagoland.pandemicresponsecommons.org @michaelfitzo @beamcb @uc-cdis/planx-qa
 elwazi-demo.planx-pla.net @michaelfitzo @uc-cdis/planx-qa


### PR DESCRIPTION
Removes @beamcb as codeowner for http://accessclinicaldata.niaid.nih.gov/
