### PR TITLE
Deploying manifestservice 0.5.0 to preprod heal

### DIFF
--- a/preprod.healdata.org/manifest.json
+++ b/preprod.healdata.org/manifest.json
@@ -16,7 +16,7 @@
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2.0.4",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2024.04",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2024.04",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:0.5.0",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2024.04",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.04",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.25.0",


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
Preprod Heal 

### Description of changes
Deploying 0.5.0 version of manifest service to preprod.healdata.org to test new metadata endpoints. 