### PR TITLE
VADC-1182: Update argo template in VA preprod

### DIFF
--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -1,6 +1,6 @@
 {
   "gaTrackingId": "G-ENMRJKCVSY",
-  "argoTemplate": "gwas-template-deadline",
+  "argoTemplate": "gwas-template-memory",
   "graphql": {
     "boardCounts": [],
     "chartCounts": [],


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-1182](https://ctds-planx.atlassian.net/browse/VADC-1182)

### Environments
* va-testing.data-commons.org


### Description of changes
* Update argo template to the new with increased memory requirements for the compute-intense step


[VADC-1182]: https://ctds-planx.atlassian.net/browse/VADC-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ