### PR TITLE
Fix: update VA test to include fix with extra global share permission check in WebAPI

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -20,7 +20,7 @@
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2024.05",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2024.05",
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:VA-pre-2024.06.05",
-    "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.05",
+    "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.10",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.05",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.06.05",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.05",


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1191

### Environments
- VA test

### Description of changes
- update VA test to include fix with extra global share permission check in WebAPI (see [here](https://github.com/uc-cdis/WebAPI/releases/tag/VA-pre-2024.06.10))