### PR TITLE
update va-testing data-portal image to 5.28.0

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -22,7 +22,7 @@
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:VA-pre-2024.06.05",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.20",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.06.05",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.28.0",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.05",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2024.05",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
va-testing.data-commons.org

### Description of changes
## New Features
  - Update Team Projects Modal for use case where user does not have teams 
    available ([#1557](https://github.com/uc-cdis/data-portal/pull/1557))
  - Updates the Discovery Action Bar so that filtered metadata is sent to the 
    ```${manifestServiceApiPath}/metadata``` after the user clicks the export 
    to workspace button, pending that they have enabled 
    ```discoveryConfig.features.exportToWorkspace.enableExportFullMetadata```. 
    The filtering removes any field that has been defined in 
    ```discoveryConfig.features.exportToWorkspace.excludedMetadataFields```, if 
    that config field exists. Note that field names in 
    ```discoveryConfig.features.exportToWorkspace.excludedMetadataFields``` can 
    represent nested fields, for example ```study_metadata.username```. ([#1534](https://github.com/uc-cdis/data-portal/pull/1534)) 
  - add html mark for accessibility ([#1546](https://github.com/uc-cdis/data-portal/pull/1546)) 
  - add NVM file to allow for using nvm command to run correct version of node 
    and npm ([#1542](https://github.com/uc-cdis/data-portal/pull/1542))
  - update documentation ([#1542](https://github.com/uc-cdis/data-portal/pull/1542)) 

## Bug Fixes
  - Fix explorer table header sorting issue ([#1554](https://github.com/uc-cdis/data-portal/pull/1554)) 
  - remove already selected covariates from list to eliminate ability to add 
    multiple times ([#1549](https://github.com/uc-cdis/data-portal/pull/1549))
  - allow for valueSummary to be null without crashing application ([#1546](https://github.com/uc-cdis/data-portal/pull/1546)) 

## Improvements
  - The DiscoveryActionBar component has been modularized into separate 
    components, utils, constants and interfaces. ([#1534](https://github.com/uc-cdis/data-portal/pull/1534)) 