### PR TITLE
(VADC-1228): add access-denied page and flag to enable on VA testing

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -22,7 +22,7 @@
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:VA-pre-2024.07.01",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.25",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.01",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.02",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.05",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2024.05",

--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -129,5 +129,9 @@
   "connectSrcCSPWhitelist": [
     "https://argo-artifact-storage-downloadable.s3.amazonaws.com",
     "https://argo-artifact-storage-downloadable-va-testing-2024.s3.amazonaws.com"
-  ]
+  ],
+  "userAccessToSite": {
+    "enabled": true,
+    "noAccessMessage": "You are not authorized to access this system. If you have any questions, please contact vadc@lists.uchicago.edu"
+  }
 }


### PR DESCRIPTION
Link to JIRA ticket if there is one: [VADC-1228](https://ctds-planx.atlassian.net/browse/VADC-1228)

### Environments
va-testing.data-commons.org

### Description of changes
- add access-denied page and flag to data portal 
- bump Portal version

[VADC-1228]: https://ctds-planx.atlassian.net/browse/VADC-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ