### PR TITLE
BIH libre mode to avoid errors

### DIFF
--- a/imaging-hub.data-commons.org/manifest.json
+++ b/imaging-hub.data-commons.org/manifest.json
@@ -37,7 +37,7 @@
     "kube_bucket": "kube_bucket.devplanetv1.gen3",
     "logs_bucket": "logs-devplanetv1-gen3",
     "useryaml_s3path": "s3://cdis-gen3-users/midrc-bih/user.yaml",
-    "tier_access_level": "private",
+    "tier_access_level": "libre",
     "public_datasets": true,
     "netpolicy": "on",
     "argocd": "true",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
BIH prod

### Description of changes
revert tier access to "libre" because "private" is causing issues: guppy returns `Please check your syntax for input \"filter\" argument`