### PR TITLE
VADC-1228: Bump VA testing portal

### DIFF
--- a/va-testing.data-commons.org/manifest.json
+++ b/va-testing.data-commons.org/manifest.json
@@ -22,7 +22,7 @@
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:VA-pre-2024.07.01",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.25",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.02",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.09",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.05",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2024.05",


### PR DESCRIPTION
Link to Jira ticket if there is one: VADC-1228

### Environments
va testing

### Description of changes
- bump va testing portal to version VA-pre-2024.07.09