### PR TITLE
(VADC-1228): Bump VA portal

### DIFF
--- a/va.data-commons.org/manifest.json
+++ b/va.data-commons.org/manifest.json
@@ -24,7 +24,7 @@
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:VA-pre-2024.06.25",
     "opencost-reporter": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/proto-opencost-reporter:chore_add-curl",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.02",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:VA-pre-2024.07.09",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.05",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.05",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2024.05",


### PR DESCRIPTION
Link to Jira ticket if there is one: VADC-1228

### Environments
va

### Description of changes
- add delay to homepage to wait for user data to prevent flicker before redirect 