### PR TITLE
changes to add missing fields like apollo id and exposure fields

### DIFF
--- a/prometheus.data-commons.org/metadata/aggregate_config.json
+++ b/prometheus.data-commons.org/metadata/aggregate_config.json
@@ -35,6 +35,7 @@
 			"primary_site": {},
 			"authz": {},
 			"subject_id": {}, 
+			"subject_apollo_id" : {},
 			"subject_race": {}, 
 			"subject_gender": {}, 
 			"subject_ethnicity": {}, 
@@ -43,7 +44,9 @@
 			"subject_cancer_grade": {}, 
 			"subject_cancer_stage": {}, 
 			"subject_year_of_birth": {}, 
-			"subject_primary_disease": {}
+			"subject_primary_disease": {},
+			"subject_type_of_exposure": {},
+			"subject_chemical_agents_of_exposure": {}
 		},
 		"settings" : {
 			"cache_drs" : true
@@ -113,6 +116,7 @@
 				"_unique_id": "path:_unique_id",
 				"commons": "path:commons",
 				"subject_id": "path:_unique_id",
+				"subject_apollo_id" : "",
 				"subject_race": "path:race",
 				"subject_gender": "path:gender",
 				"subject_ethnicity": "path:ethnicity",
@@ -143,6 +147,7 @@
 				"_unique_id": "",
 				"commons": {"path":"platform_id", "default" : "" },
 				"subject_id": "",
+				"subject_apollo_id" : "",
 				"subject_race": {"path": "race", "default": ""},
 				"subject_gender": {"path": "gender", "default": ""},
 				"subject_ethnicity": {"path": "ethnicity", "default": ""},
@@ -171,6 +176,7 @@
 				"disease_type": "path:disease_type",
 				"primary_site": "path:primary_site",
 				"subject_id": "path:submitter_id",
+				"subject_apollo_id" : "",
 				"subject_race": "path:demographic.race",
 				"subject_gender": "path:demographic.gender",
 				"subject_ethnicity": "path:demographic.ethnicity",
@@ -180,6 +186,7 @@
 				"subject_cancer_stage": "path:diagnoses.ajcc_pathologic_stage",
 				"subject_year_of_birth": "",
 				"subject_primary_disease": "path:diagnoses.primary_diagnosis",
+				"subject_type_of_exposure": "path:exposures.tobacco_smoking_status",
 				"commons_url" : "api.gdc.cancer.gov"
 			}
 		}


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
Prometheus.data-commons.org

### Description of changes
Added missing fields in agg mds like `subject_apollo_id`, `subject_type_of_exposure` and `subject_chemical_agents_of_exposure`