### PR TITLE
Bump portal to 5.33.1 in midrcstaging

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -20,7 +20,7 @@
     "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-v3.8.0",
     "orthanc": "docker.io/osimis/orthanc:master",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.08",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.33.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.33.1",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.08",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.08",
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2024.08",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- staging.midrc.org

### Description of changes
- bumping portal to 5.33.1 for Grafana Faro code changes