### PR TITLE
Add "arborist_url" to global for vpodc

### DIFF
--- a/vpodc.data-commons.org/manifest.json
+++ b/vpodc.data-commons.org/manifest.json
@@ -48,6 +48,7 @@
     "netpolicy": "on",
     "maintenance_mode": "off",
     "argocd": "true",
+    "arborist_url": "http://arborist-service",
     "waf_enabled": "true",
     "pdb": "on",
     "karpenter": "true",


### PR DESCRIPTION
https://github.com/uc-cdis/cloud-automation/blob/master/gen3/bin/kube-setup-ohdsi.sh#L86C27-L86C54 

ohdsi setup script requires this in manifest.

Link to Jira ticket if there is one:

### Environments
- vpodc.data-commons.org

### Description of changes
- Add arborist-url to global