### PR TITLE
-Bump portal for gen3qa.kidsfirstdrc.org to allow for user session tr…

### DIFF
--- a/gen3qa.kidsfirstdrc.org/manifest.json
+++ b/gen3qa.kidsfirstdrc.org/manifest.json
@@ -17,7 +17,7 @@
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.08",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.08",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2024.08",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2024.08",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.33.1",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0"
   },
   "arborist": {


### PR DESCRIPTION
…acking in grafana

Link to Jira ticket if there is one:

### Environments


### Description of changes
Bumps portal version for kf external qa (gen3qa.kidsfirstdrc.org) to allow for user session tracking in Grafana