### PR TITLE
-Bump portal and config for kf prod to allow for user session trackin…

### DIFF
--- a/data.kidsfirstdrc.org/manifest.json
+++ b/data.kidsfirstdrc.org/manifest.json
@@ -16,7 +16,7 @@
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.08",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.08",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2024.08",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2024.08",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.33.1",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0"
   },
   "arborist": {

--- a/data.kidsfirstdrc.org/portal/gitops.json
+++ b/data.kidsfirstdrc.org/portal/gitops.json
@@ -1,4 +1,8 @@
 {
+  "grafanaFaroConfig": {
+    "grafanaFaroEnable": true,
+    "grafanaFaroNamespace": "kfprod"
+  },
   "graphql": {
     "boardCounts": [
       {


### PR DESCRIPTION
…g in Grafana

Link to Jira ticket if there is one:

### Environments


### Description of changes
Bumps portal and adds config for kf prod (data.kidsfirstdrc.org) to allow for user session tracking in Grafana