### PR TITLE
-Bump portal and add config for accessclinicaldata (niaid prod) to al…

### DIFF
--- a/accessclinicaldata.niaid.nih.gov/manifest.json
+++ b/accessclinicaldata.niaid.nih.gov/manifest.json
@@ -16,7 +16,7 @@
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2024.08",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2024.08",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2024.08",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2024.08",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.33.1",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2024.08",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2024.08",

--- a/accessclinicaldata.niaid.nih.gov/portal/gitops.json
+++ b/accessclinicaldata.niaid.nih.gov/portal/gitops.json
@@ -1,5 +1,9 @@
 {
   "gaTrackingId": "G-PYX1509S24",
+  "grafanaFaroConfig": {
+    "grafanaFaroEnable": true,
+    "grafanaFaroNamespace": "accessclinicaldataprod"
+  },
   "DAPTrackingURL": "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIH&subagency=NIAID",
   "ddEnv": "NIAID",
   "ddUrl": "ddog-gov.com",


### PR DESCRIPTION
…low for user session tracking in Grafana

Link to Jira ticket if there is one:

### Environments


### Description of changes
Bumps portal version and adds config for niaid prod (accessclinicaldata.niaid.nih.gov) to allow for user session tracking in Grafana