### PR TITLE
making changes for heal prod to use IRSA for the batch-export job

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6919,15 +6919,6 @@
         "line_number": 6
       }
     ],
-    "healdata.org/manifest.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "healdata.org/manifest.json",
-        "hashed_secret": "ae4a2a671a528744059cd818de9af9e13005563b",
-        "is_verified": false,
-        "line_number": 81
-      }
-    ],
     "healdata.org/manifests/hatchery/hatchery.json": [
       {
         "type": "Base64 High Entropy String",
@@ -9588,5 +9579,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-07T16:06:43Z"
+  "generated_at": "2024-11-12T20:03:52Z"
 }

--- a/healdata.org/manifest.json
+++ b/healdata.org/manifest.json
@@ -48,7 +48,7 @@
       "activeDeadlineSeconds": 600,
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/batch-export:feat_GPE-1219",
+        "image": "quay.io/cdis/batch-export:integration202412",
         "pull_policy": "Always",
         "labels": {
           "internet": "yes"

--- a/healdata.org/manifest.json
+++ b/healdata.org/manifest.json
@@ -44,10 +44,11 @@
     {
       "name": "batch-export",
       "action": "batch-export",
+      "serviceAccountName": "batch-export-sa",
       "activeDeadlineSeconds": 600,
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/batch-export:2024.10",
+        "image": "quay.io/cdis/batch-export:feat_GPE-1219",
         "pull_policy": "Always",
         "labels": {
           "internet": "yes"
@@ -61,27 +62,20 @@
                 "key": "hostname"
               }
             }
-          }
-        ],
-        "volumeMounts": [
+          },
           {
-            "name": "batch-export-creds-volume",
-            "readOnly": true,
-            "mountPath": "/batch-export-creds.json",
-            "subPath": "config.json"
+            "name": "BUCKET",
+            "valueFrom": {
+              "configMapKeyRef": {
+                "name": "batch-export-g3auto",
+                "key": "bucket_name"
+              }
+            }
           }
         ],
         "cpu-limit": "1",
         "memory-limit": "1Gi"
       },
-      "volumes": [
-        {
-          "name": "batch-export-creds-volume",
-          "secret": {
-            "secretName": "batch-export-g3auto"
-          }
-        }
-      ],
       "restart_policy": "Never"
     }
   ],


### PR DESCRIPTION
### Environments
Heal Prod

### Description of changes
The batch export job now will rely on a service account instead of AWS access keys. This change is more secure and prevents any downtime caused by expired keys. In order to implement this change, we need to change the sower-job image as well as the volume mounts and environment variables to support the new batch export image.