### PR TITLE
MIDRCValidate: updating validatestaging.midrc.org with new 1.3.7 updates

### DIFF
--- a/validate.midrc.org/manifest.json
+++ b/validate.midrc.org/manifest.json
@@ -160,7 +160,7 @@
     "kube_bucket": "kube-midrcvalidate-gen3",
     "dispatcher_job_num": "10",
     "logs_bucket": "logs-midrcprod-gen3",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.5/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.3.7/schema.json",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",
     "netpolicy": "on",


### PR DESCRIPTION
Updating MIDRC validatestaging.midrc.org with 1.3.7 updates.
