### PR TITLE
Bump prometheus DD to 0.0.5

### DIFF
--- a/prometheus.data-commons.org/manifest.json
+++ b/prometheus.data-commons.org/manifest.json
@@ -36,7 +36,7 @@
     "environment": "pdp-commons",
     "hostname": "prometheus.data-commons.org",
     "revproxy_arn": "arn:aws:acm:us-east-1:851725307933:certificate/94dc6b22-6ad2-481f-aff5-59ad7381e9c6",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/pdp_dictionary/0.0.4/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/pdp_dictionary/0.0.5/schema.json",
     "dispatcher_job_num": "10",
     "portal_app": "gitops",
     "sync_from_dbgap": "False",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- prometheus.data-commons.org

### Description of changes
Bump data dictionary to 0.0.5
