### PR TITLE
change Data Commons graph to show data from metabolomics and VMOAT

### DIFF
--- a/prometheus.data-commons.org/portal/gitops.json
+++ b/prometheus.data-commons.org/portal/gitops.json
@@ -314,7 +314,7 @@
             },
             {
               "name": "Data Commons",
-              "field": "commons",
+              "field": "data_source",
               "contentType": "string",
               "includeIfNotAvailable": false
             },


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
[prometheus](https://prometheus.data-commons.org/)

### Description of changes
change Data Commons graph and use `data_source` field to show data from metabolomics and VMOAT