### PR TITLE
Update docs links from legacy to new docs at docs.gen3.org

### DIFF
--- a/brh.data-commons.org/portal/gitops.json
+++ b/brh.data-commons.org/portal/gitops.json
@@ -166,8 +166,8 @@
         "enableDownloadManifest": true,
         "downloadManifestButtonText": "Download",
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         }
       },
       "pageTitle": {

--- a/diseasedatahub.org/portal/gitops.json
+++ b/diseasedatahub.org/portal/gitops.json
@@ -102,7 +102,7 @@
     "topBar": {
       "items": [
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         }
       ]

--- a/elwazi-demo.planx-pla.net/portal/gitops.json
+++ b/elwazi-demo.planx-pla.net/portal/gitops.json
@@ -193,7 +193,7 @@
           "name": "Submit Data"
         },
         {
-          "link": "https://gen3.org/resources/user",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Gen3 Documentation"
         },
         {

--- a/healdata.org/portal/gitops.json
+++ b/healdata.org/portal/gitops.json
@@ -182,8 +182,8 @@
         "studyMetadataFieldName": "study_metadata",
         "enableDownloadStudyMetadata": true,
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         },
         "verifyExternalLogins": true
       },

--- a/vpodc.data-commons.org/portal/gitops.json
+++ b/vpodc.data-commons.org/portal/gitops.json
@@ -131,7 +131,7 @@
           "name": "Submit Data"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         }
       ],


### PR DESCRIPTION
Change link-outs to documentation from legacy documentation at [gen3.org](http://gen3.org/) to new mkdocs documentation at [docs.gen3.org](http://docs.gen3.org/)