### PR TITLE
Update legacy docs links to docs.gen3.org

### DIFF
--- a/brhstaging.data-commons.org/portal/gitops.json
+++ b/brhstaging.data-commons.org/portal/gitops.json
@@ -173,8 +173,8 @@
         "enableDownloadManifest": true,
         "downloadManifestButtonText": "Download",
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         }
       },
       "pageTitle": {

--- a/chicagoland.pandemicresponsecommons.org/portal/gitops.json
+++ b/chicagoland.pandemicresponsecommons.org/portal/gitops.json
@@ -110,7 +110,7 @@
           "name": "Cite"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         },
         {
@@ -1344,8 +1344,8 @@
         "externalWebsiteURL": "https://pandemicresponsecommons.org",
         "fillRequestFormCheckField": "_medical_sample_id",
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         },
         "verifyExternalLogins": true
       },

--- a/data.midrc.org/portal/gitops.json
+++ b/data.midrc.org/portal/gitops.json
@@ -308,7 +308,7 @@
           "name": "Resources"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Gen3"
         },
         {

--- a/preprod.healdata.org/portal/gitops.json
+++ b/preprod.healdata.org/portal/gitops.json
@@ -179,8 +179,8 @@
         "studyMetadataFieldName": "study_metadata",
         "enableDownloadStudyMetadata": true,
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         },
         "verifyExternalLogins": true
       },

--- a/prometheus.data-commons.org/portal/gitops.json
+++ b/prometheus.data-commons.org/portal/gitops.json
@@ -164,8 +164,8 @@
         "enableDownloadManifest": true,
         "downloadManifestButtonText": "Download",
         "documentationLinks": {
-          "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-          "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+          "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+          "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
         }
       },
       "pageTitle": {

--- a/staging.midrc.org/portal/gitops.json
+++ b/staging.midrc.org/portal/gitops.json
@@ -308,7 +308,7 @@
           "name": "Resources"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Gen3"
         },
         {

--- a/validate.midrc.org/portal/gitops.json
+++ b/validate.midrc.org/portal/gitops.json
@@ -304,7 +304,7 @@
           "name": "Resources"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Gen3"
         },
         {

--- a/validatestaging.midrc.org/portal/gitops.json
+++ b/validatestaging.midrc.org/portal/gitops.json
@@ -292,7 +292,7 @@
           "name": "Resources"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Gen3"
         },
         {


### PR DESCRIPTION
Change link-outs to documentation from legacy documentation at [gen3.org](http://gen3.org/) to new mkdocs documentation at [docs.gen3.org](http://docs.gen3.org/)