### PR TITLE
Update VADC email to vadc-support@gen3.org

### DIFF
--- a/va-testing.data-commons.org/dashboard/Public/documentation/_sources/index.rst.txt
+++ b/va-testing.data-commons.org/dashboard/Public/documentation/_sources/index.rst.txt
@@ -79,7 +79,7 @@ The button for VA Data Commons Documentation takes you to this page.
 ~~~~~~~~~~~~~~~~~
 
 If you need help, the Email Support button allows you to send a message
-to our help desk at vadc@lists.uchicago.edu. You may expect a response
+to our help desk at vadc-support@gen3.org. You may expect a response
 within 2 business days.
 
 Data Access and Analysis
@@ -257,7 +257,7 @@ the cohort’s information.
 
 We expect that this documentation in addition to the OHDSI tutorials are
 sufficient for most analyses that users will attempt. If you have any
-questions, please contact us at vadc@lists.uchicago.edu.
+questions, please contact us at vadc-support@gen3.org.
 
 **Gen3 GWAS**
 -------------
@@ -570,7 +570,7 @@ from the Actions Menu.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Many reasons can cause workflows to fail, and some of them may be
-transient. Please reach out to vadc@lists.uchicago.edu with any further
+transient. Please reach out to vadc-support@gen3.org with any further
 questions. In your message please provide us with the serial name of
 your workflow and the step in which your GWAS failed (mentioned in your
 error message). A response should be expected with 2 business days.
@@ -585,7 +585,7 @@ These may differ from the analysis you ran initially, and these
 differences might affect the outcome. For these reasons, the retry
 action is only applicable to failed workflows. If you have any
 questions, please feel free to contact us via email
-vadc@lists.uchicago.edu.
+vadc-support@gen3.org.
 
 Frequently Asked Questions
 ==========================
@@ -601,7 +601,7 @@ These resources contain a lot of useful information, particularly you
 might find it useful to read about `Cohort
 Definition <https://ohdsi.github.io/TheBookOfOhdsi/Cohorts.html#Cohorts>`__.
 If you need help, please reach out to our help desk at
-vadc@lists.uchicago.edu
+vadc-support@gen3.org
 
 **What are harmonized variables?**
 ----------------------------------

--- a/va-testing.data-commons.org/portal/gitops.json
+++ b/va-testing.data-commons.org/portal/gitops.json
@@ -56,7 +56,7 @@
           "name": "Help and Guidance"
         },
         {
-          "link": "vadc@lists.uchicago.edu",
+          "link": "vadc-support@gen3.org",
           "name": "Email Support"
         }
       ],
@@ -67,7 +67,7 @@
       "subTitle": "search, compare, and analyze data",
       "text": "The VA Data Commons supports the research and analysis of US military Veteran medical and genomic data and aims to accelerate scientific discovery and development of therapies, diagnostic tests, and other technologies for improving the lives of Veterans and beyond.",
       "contact": "If you have any questions about access or the registration process, please contact ",
-      "email": "vadc@lists.uchicago.edu"
+      "email": "vadc-support@gen3.org"
     },
     "systemUse": {
       "systemUseTitle": "VA systems are intended for Academic and Institutional Users",
@@ -140,7 +140,7 @@
   ],
   "userAccessToSite": {
     "enabled": true,
-    "noAccessMessage": "You are not authorized to access this system. If you have any questions, please contact vadc@lists.uchicago.edu"
+    "noAccessMessage": "You are not authorized to access this system. If you have any questions, please contact vadc-support@gen3.org"
   },
   "componentToResourceMapping": { 
     "Workspace": {

--- a/va.data-commons.org/dashboard/Public/documentation/_sources/index.rst.txt
+++ b/va.data-commons.org/dashboard/Public/documentation/_sources/index.rst.txt
@@ -79,7 +79,7 @@ The button for VA Data Commons Documentation takes you to this page.
 ~~~~~~~~~~~~~~~~~
 
 If you need help, the Email Support button allows you to send a message
-to our help desk at vadc@lists.uchicago.edu. You may expect a response
+to our help desk at vadc-support@gen3.org. You may expect a response
 within 2 business days.
 
 Data Access and Analysis
@@ -257,7 +257,7 @@ the cohort’s information.
 
 We expect that this documentation in addition to the OHDSI tutorials are
 sufficient for most analyses that users will attempt. If you have any
-questions, please contact us at vadc@lists.uchicago.edu.
+questions, please contact us at vadc-support@gen3.org.
 
 **Gen3 GWAS**
 -------------
@@ -570,7 +570,7 @@ from the Actions Menu.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Many reasons can cause workflows to fail, and some of them may be
-transient. Please reach out to vadc@lists.uchicago.edu with any further
+transient. Please reach out to vadc-support@gen3.org with any further
 questions. In your message please provide us with the serial name of
 your workflow and the step in which your GWAS failed (mentioned in your
 error message). A response should be expected with 2 business days.
@@ -585,7 +585,7 @@ These may differ from the analysis you ran initially, and these
 differences might affect the outcome. For these reasons, the retry
 action is only applicable to failed workflows. If you have any
 questions, please feel free to contact us via email
-vadc@lists.uchicago.edu.
+vadc-support@gen3.org.
 
 Frequently Asked Questions
 ==========================
@@ -601,7 +601,7 @@ These resources contain a lot of useful information, particularly you
 might find it useful to read about `Cohort
 Definition <https://ohdsi.github.io/TheBookOfOhdsi/Cohorts.html#Cohorts>`__.
 If you need help, please reach out to our help desk at
-vadc@lists.uchicago.edu
+vadc-support@gen3.org
 
 **What are harmonized variables?**
 ----------------------------------

--- a/va.data-commons.org/portal/gitops.json
+++ b/va.data-commons.org/portal/gitops.json
@@ -59,7 +59,7 @@
           "name": "Help and Guidance"
         },
         {
-          "link": "vadc@lists.uchicago.edu",
+          "link": "vadc-support@gen3.org",
           "name": "Email Support"
         }
       ],
@@ -70,7 +70,7 @@
       "subTitle": "search, compare, and analyze data",
       "text": "The VA Data Commons supports the research and analysis of US military Veteran medical and genomic data and aims to accelerate scientific discovery and development of therapies, diagnostic tests, and other technologies for improving the lives of Veterans and beyond.",
       "contact": "If you have any questions about access or the registration process, please contact ",
-      "email": "vadc@lists.uchicago.edu"
+      "email": "vadc-support@gen3.org"
     },
     "systemUse": {
       "systemUseTitle": "VA systems are intended for Academic and Institutional Users",
@@ -142,7 +142,7 @@
   "ddUrl": "ddog-gov.com",
   "userAccessToSite": {
     "enabled": true,
-    "noAccessMessage": "You are not authorized to access this system. If you have any questions, please contact vadc@lists.uchicago.edu"
+    "noAccessMessage": "You are not authorized to access this system. If you have any questions, please contact vadc-support@gen3.org"
   },
   "componentToResourceMapping": { 
     "Workspace": {


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/VADC-1685
all email references that currently are [vadc@lists.uchicago.edu](mailto:vadc@lists.uchicago.edu) → change to [vadc-support@gen3.org](mailto:vadc-support@gen3.org)
For Feb 17 release