### PR TITLE
MIDRC Staging Orthanc to non-AL2 v24.3.5

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -19,7 +19,7 @@
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2025.03",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2025.03",
     "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-v3.9.3",
-    "orthanc": "docker.io/osimis/orthanc:master",
+    "orthanc": "quay.io/cdis/gen3-orthanc:orthancteam-master-gen3-24.3.5",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2025.03",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2025.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2025.03",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
MIDRC Staging

### Description of changes
Pin Orthanc to our own build of the 24.3.5 image (https://github.com/uc-cdis/orthanc-builder) to avoid alerts about a pod being down when automation tries to deploy `docker.io/osimis/orthanc:master`, which doesn't support the version of the DB 24.3.5 is running:
```
PostgreSQL plugin is incompatible with database schema revision: 2
Exception in database back-end: Error with the database engine
```