### PR TITLE
Update sheepdog to 5.2.1 in BIH Staging

### DIFF
--- a/bihstaging.data-commons.org/manifest.json
+++ b/bihstaging.data-commons.org/manifest.json
@@ -20,7 +20,7 @@
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2025.03",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2025.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2025.03",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2025.03",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:5.2.1",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2025.03",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2025.03",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2025.03",


### PR DESCRIPTION
Link to Jira ticket if there is one: [MIDRC-946](https://ctds-planx.atlassian.net/browse/MIDRC-946)

### Environments
* BIH Staging

### Description of changes
* Updated Sheepdog to version `5.2.1`

[MIDRC-946]: https://ctds-planx.atlassian.net/browse/MIDRC-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ