### PR TITLE
Update portal to 5.37.2 in staging.midrc.org

### DIFF
--- a/staging.midrc.org/manifest.json
+++ b/staging.midrc.org/manifest.json
@@ -21,7 +21,7 @@
     "ohif-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-v3.9.3",
     "orthanc": "quay.io/cdis/gen3-orthanc:orthancteam-master-gen3-24.3.5",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2025.03",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2025.03",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.37.2",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2025.03",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2025.03",
     "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2025.03",


### PR DESCRIPTION
Update portal to `5.37.2` in staging.midrc.org

Link to Jira ticket if there is one:

### Environments
* staging.midrc.org

### Description of changes
* Update Data-portal in MIDRC staging to `5.37.2`