### PR TITLE
Remove hatchery from BIH staging and prod

### DIFF
--- a/bihstaging.data-commons.org/manifest.json
+++ b/bihstaging.data-commons.org/manifest.json
@@ -13,7 +13,6 @@
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2025.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "frontend-framework": "quay.io/cdis/bih-data-commons:1.1.6",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2025.03",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2025.03",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2025.03",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2025.03",

--- a/imaging-hub.data-commons.org/manifest.json
+++ b/imaging-hub.data-commons.org/manifest.json
@@ -13,7 +13,6 @@
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2025.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "frontend-framework": "quay.io/cdis/bih-data-commons:1.1.6",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2025.03",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2025.03",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2025.03",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2025.03",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
BIH staging and prod

### Description of changes
Remove hatchery. It had been added [here](https://github.com/uc-cdis/cdis-manifest/pull/7618/commits/ca54071da6c40dc425be043db6ff0d57d8be7b5a) because of an issue running portal without it:

> data-portal seems to require hatchery to be running in order to function correctly

(see [this thread](https://cdis.slack.com/archives/C06CHT5HZDZ/p1722612627055849))

It looks like this isn't an issue anymore. I tested removing hatchery in staging and portal+FEF still seem to work fine.