### PR TITLE
changes in metabolomics, non synthetic to synthetic, added sub_data_s…

### DIFF
--- a/prometheus.data-commons.org/metadata/aggregate_config.json
+++ b/prometheus.data-commons.org/metadata/aggregate_config.json
@@ -720,13 +720,14 @@
 				"commons": "path:commons",
 				"study_url": "path:study_url",
 				"data_source" : "path:data_source",
+				"sub_data_source" : "path:sub_data_source",
 				"_subjects_count": {
 					"path": "_subjects_count",
 					"default": 0
 				},
 				"__manifest": "path:__manifest",
 				"commons_url": "externalgen3.prometheus.data-commons.org",
-				"is_synthetic": "Yes"
+				"is_synthetic": "No"
 			}
 		},
 		"Metabolomic-subject-level-metadata": {
@@ -833,9 +834,10 @@
 				"subject_year_of_birth": "path:year_of_birth",
 				"subject_primary_disease": "",
 				"data_source" : "path:data_source",
+				"sub_data_source" : "path:sub_data_source",
 				"commons_url": "externalgen3.prometheus.data-commons.org",
 				"prometheus_global_id" : "path:prometheus_global_id",
-				"is_synthetic": "Yes"
+				"is_synthetic": "No"
 			}
 		},
 		"TCIA-study-level-metadata": {


### PR DESCRIPTION
[PROM-239](https://ctds-planx.atlassian.net/browse/PROM-239?atlOrigin=eyJpIjoiOWE0MGNkZmYwMzYyNGNkMTlmZWY1MTc4YTQxYmQ0ZTEiLCJwIjoiaiJ9)

### Environments
prometheus.data-commons.org

### Description of changes
changes in metabolomics to switch the nonsynthetic to synthetic and added a `sub_data_source` field to show where data came from.

[PROM-239]: https://ctds-planx.atlassian.net/browse/PROM-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ