### PR TITLE
Roll back fence to 2025.02 in midrc

### DIFF
--- a/data.midrc.org/manifest.json
+++ b/data.midrc.org/manifest.json
@@ -11,7 +11,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2025.04",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2025.04",
     "dicom-server": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-orthanc:gen3-0.1.2",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2025.04",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2025.02",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2025.04",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2025.04",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- data.midrc.org

### Description of changes
- temporarily roll back fence to 2025.02 while we work on a fips fix for /user/registration