### PR TITLE
Temporarily stop dbGaP Sync for BDC Prod

### DIFF
--- a/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
+++ b/gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json
@@ -207,7 +207,7 @@
     "portal_app": "gitops",
     "kube_bucket": "kube-stageprod-gen3",
     "logs_bucket": "logs-stageprod-gen3",
-    "sync_from_dbgap": "True",
+    "sync_from_dbgap": "False",
     "useryaml_s3path": "s3://cdis-gen3-users/stageprod/user.yaml",
     "public_datasets": true,
     "tier_access_level": "regular",
@@ -239,8 +239,8 @@
   "scaling": {
     "arborist": {
       "strategy": "auto",
-      "min": 2,
-      "max": 4,
+      "min": 4,
+      "max": 8,
       "targetCpu": 40
     },
     "portal": {


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- BDC Prod

### Description of changes
- Stop dbGaP sync to unblock external developers on BDC.